### PR TITLE
Migrate the documentation to readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+# build:
+#   os: ubuntu-22.04
+#   tools:
+#     python: "3.10"
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/docs/build-ui.md
+++ b/docs/build-ui.md
@@ -11,9 +11,9 @@ project.
 The `s3gw-ui` application is associated with a `Dockerfile` and adheres to some
 conventions:
 
-* Dockerfile build context must be placed inside a directory placed alongside to
+- Dockerfile build context must be placed inside a directory placed alongside to
   the `s3gw-ui` project.
-* You should be able to build that application from that directory with:
+- You should be able to build that application from that directory with:
 
 ```text
 npm install
@@ -27,7 +27,7 @@ has been built.
 
 Make sure you've installed the following applications:
 
-* Podman
+- Podman
 
 The build script expects the following directory hierarchy.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -8,7 +8,7 @@ This documentation will guide you through the several steps to build the
 > **NOTE:** The absolute paths mentioned in this document may be different
 > on your system.
 
-### Prerequisites
+## Prerequisites
 
 Make sure you've installed the following applications:
 
@@ -33,7 +33,7 @@ The build scripts expect the following directory hierarchy.
    ...
 ```
 
-### Building the radosgw binary
+## Building the radosgw binary
 
 To build the `radosgw` binary, a containerized build environment is used.
 This container can be built by running the following command:
@@ -74,7 +74,7 @@ podman run \
   localhost/build-radosgw
 ```
 
-### Build the s3gw container image
+## Build the s3gw container image
 
 If the Ceph `radosgw` binary is compiled, the container image can be build
 with the following commands:
@@ -99,7 +99,7 @@ environment variable.
 The container image name is `s3gw` by default. This can be customized via
 the environment variable `IMAGE_NAME`.
 
-### Running the s3gw container
+## Running the s3gw container
 
 Finally, you can run the `s3gw` container with the following command:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,9 +7,14 @@ everyone to check out our [issues list][1]
 and either file a new issue if the observed behavior has not been reported
 yet, or to contribute with further details to an existing issue.
 
+## Project Board
+
+We track our progress in this [Github project][2] board.
+
 ## Discussion
 
-You can join us in [Slack][2].
+You can join us in [Slack][3].
 
 [1]: https://github.com/aquarist-labs/s3gw/issues
 [2]: https://join.slack.com/t/aquaristlabs/shared_invite/zt-nphn0jhg-QYKw__It8JPMkUR_sArOug
+[3]: https://github.com/orgs/aquarist-labs/projects/5/views/1

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -6,26 +6,28 @@ deciders: {list everyone involved in the decision}
 consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
 informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
+
 # {short title of solved problem and solution}
 
 ## Context and Problem Statement
 
 {Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
- You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
 
 <!-- This is an optional element. Feel free to remove. -->
+
 ## Decision Drivers
 
-* {decision driver 1, e.g., a force, facing concern, …}
-* {decision driver 2, e.g., a force, facing concern, …}
-* … <!-- numbers of drivers can vary -->
+- {decision driver 1, e.g., a force, facing concern, …}
+- {decision driver 2, e.g., a force, facing concern, …}
+- … <!-- numbers of drivers can vary -->
 
 ## Considered Options
 
-* {title of option 1}
-* {title of option 2}
-* {title of option 3}
-* … <!-- numbers of options can vary -->
+- {title of option 1}
+- {title of option 2}
+- {title of option 3}
+- … <!-- numbers of options can vary -->
 
 ## Decision Outcome
 
@@ -33,52 +35,58 @@ Chosen option: "{title of option 1}", because
 {justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
 
 <!-- This is an optional element. Feel free to remove. -->
+
 ### Positive Consequences
 
-* {e.g., improvement of one or more desired qualities, …}
-* …
+- {e.g., improvement of one or more desired qualities, …}
+- …
 
 <!-- This is an optional element. Feel free to remove. -->
+
 ### Negative Consequences
 
-* {e.g., compromising one or more desired qualities, …}
-* …
+- {e.g., compromising one or more desired qualities, …}
+- …
 
 <!-- This is an optional element. Feel free to remove. -->
+
 ## Validation
 
 {describe how the implementation of/compliance with the ADR is validated. E.g., by a review or an ArchUnit test}
 
 <!-- This is an optional element. Feel free to remove. -->
+
 ## Pros and Cons of the Options
 
 ### {title of option 1}
 
 <!-- This is an optional element. Feel free to remove. -->
+
 {example | description | pointer to more information | …}
 
-* Good, because {argument a}
-* Good, because {argument b}
+- Good, because {argument a}
+- Good, because {argument b}
 <!-- use "neutral" if the given argument weights neither for good nor bad -->
-* Neutral, because {argument c}
-* Bad, because {argument d}
-* … <!-- numbers of pros and cons can vary -->
+- Neutral, because {argument c}
+- Bad, because {argument d}
+- … <!-- numbers of pros and cons can vary -->
 
 ### {title of other option}
 
 {example | description | pointer to more information | …}
 
-* Good, because {argument a}
-* Good, because {argument b}
-* Neutral, because {argument c}
-* Bad, because {argument d}
-* …
+- Good, because {argument a}
+- Good, because {argument b}
+- Neutral, because {argument c}
+- Bad, because {argument d}
+- …
 
 <!-- This is an optional element. Feel free to remove. -->
+
 ## More Information
 
 {You might want to provide additional evidence/confidence for the decision outcome here and/or
- document the team agreement on the decision and/or
- define when this decision when and how the decision should be realized and if/when it should be re-visited and/or
- how the decision is validated.
- Links to other decisions and resources might here appear as well.}
+document the team agreement on the decision and/or
+define when this decision when and how the decision should be realized and if/when it should be re-visited and/or
+how the decision is validated.
+Links to other decisions and resources might here appear as well.}

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,8 +1,5 @@
 # Developing the S3 Gateway
 
-You can refer to the [development](./docs/development.md) section to understand
-how to build the `s3gw` container image.
-
 ## Introduction
 
 Given we are still setting up the project, figuring out requirements, and
@@ -57,7 +54,7 @@ bin/radosgw -i foo -d --no-mon-config --debug-rgw 15 \
 
 Once the daemon is running, and outputting its logs to the terminal, one can
 start issuing commands to the daemon. We rely on `s3cmd`, which can be found
-on [github][4] or obtained through `pip`.
+on [Github][4] or obtained through `pip`.
 
 `s3cmd` will require to be configured to talk to RGW. This can be achieved by
 first running `s3cmd -c $(pwd)/.s3cfg --configure`. By default, the

--- a/docs/env-k3s.md
+++ b/docs/env-k3s.md
@@ -52,7 +52,7 @@ http://s3gw-ui-no-tls.local:30080
 
 This README will guide you through the setup of a K3s cluster on bare metal.
 If you are looking for K3s cluster running on virtual machines,
-refer to our [K3s on virtual machines](./README.vm.md).
+refer to [K3s on virtual machines](#k3s-on-virtual-machines).
 
 ### Disabling firewalld
 
@@ -119,17 +119,7 @@ Backup Target Credential Secret: `s3gw-secret`
 Follow this guide if you wish to run a K3s cluster installed on virtual
 machines. You will have a certain degree of choice in terms of customization
 options. If you are looking for a more lightweight environment running directly
-on bare metal, refer to our [K3s on bare metal](./README.bm.md).
-
-### Table of Contents
-
-- [Description](#description)
-- [Requirements](#requirements)
-- [Supported Vagrant boxes](#supported-vagrant-boxes)
-- [Building the environment](#building-the-environment)
-- [Destroying the environment](#destroying-the-environment)
-- [Accessing the environment](#accessing-the-environment)
-  - [ssh](#ssh)
+on bare metal, refer to [K3s on bare metal](#k3s-on-bare-metal).
 
 ### Description
 

--- a/docs/env-k8s.md
+++ b/docs/env-k8s.md
@@ -4,7 +4,7 @@ Follow this guide if you wish to run an `s3gw` image on the latest stable
 Kubernetes release. You will be able to quickly build a cluster installed on a
 set of virtual machines. You will have a certain degree of choice in terms of
 customization options. If you are looking for a more lightweight environment
-running directly on bare metal, refer to our [K3s section](./README.k3s.md).
+running directly on bare metal, refer to our [K3s section](env-k3s.md).
 
 ## Table of Contents
 

--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -1,0 +1,122 @@
+# Installation and options
+
+In order to install s3gw using Helm, from this repository directly, first you
+must clone the repo:
+
+```bash
+  git clone https://github.com/aquarist-labs/s3gw-charts.git
+```
+
+Before installing, familiarize yourself with the options, if necessary provide
+your own `values.yaml` file.
+Then change into the repository and install using helm:
+
+```bash
+  cd s3gw-charts
+  helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE
+  --create-namespace -f /path/to/your/custom/values.yaml
+```
+
+## Dependencies
+
+### Traefik
+
+If you intend to install s3gw with an ingress resource, you must ensure your
+environment is equipped with a [Traefik](https://helm.traefik.io/traefik)
+ingress controller.
+
+## Options
+
+The helm chart can be customized for your Kubernetes environment. To do so,
+either provide a `values.yaml` file with your settings, or set the options on
+the command line directly using `helm --set key=value`.
+
+### Hostname
+
+Use the `hostname` setting to configure the hostname under which you would like
+to make the gateway available:
+
+```yaml
+hostname: s3gw.local
+```
+
+The plain HTTP endpoint will then be generated as: `no-tls-s3gw.local`
+
+### Ingress Options
+
+The chart can install an ingress resource for a Traefik ingress controller:
+
+```yaml
+enableIngress: true
+```
+
+### TLS Certificates
+
+provide the TLS certificate in the `values.yaml` file to enable TLS at the
+ingress.
+Note that the connection between the ingress and s3gw itself within the cluster
+will not be TLS protected.
+
+```yaml
+tls:
+  crt: PUT_YOUR_CERTIFICATE_HERE
+  key: PUT_YOUR_CERTIFICATES_KEY_HERE
+```
+
+### Existing Volumes
+
+The s3gw is best deployed ontop of a [longhorn](https://longhorn.io) volume. If
+you have longhorn installed in your cluster, all appropriate resources will be
+automatically deployed for you.
+Make sure the `storageType` is set to `"longhorn"` and the correct size for the
+claim is set in `storageSize`:
+
+```yaml
+storageType: "longhorn"
+storageSize: 10Gi
+```
+
+However if you want to use s3gw with other storage providers, you can do so too.
+You must first deploy a persistent volume claim for your storage provider. Then
+you deploy s3gw and set it to use that persistent volume claim (pvc) with:
+
+```yaml
+storageType: "pvc"
+storage: the-name-of-the-pvc
+```
+
+s3gw will then reuse that pvc instead of deploying a longhorn volume.
+
+You can also use local filesystem storage instead, by setting `storageType` to
+`"local"`, `storageSize` to the desired quota and `storage` to the path on the
+hosts filesystem, e.g:
+
+```yaml
+storageType: "local"
+storageSize: 10Gi
+storage: /mnt/extra-storage/
+```
+
+### Image Settings
+
+In some cases, custom image settings are needed, e.g. in an air-gapped
+environment, or for developers. In that case, you can modify the registry and
+image settings:
+
+```yaml
+imageRegistry: "ghcr.io/aquarist-labs"
+imageName: "s3gw"
+imageTag: "latest"
+imagePullPolicy: "Always"
+imageRegistry_ui: "ghcr.io/aquarist-labs"
+imageName_ui: "s3gw-ui"
+imageTag_ui: "latest"
+imagePullPolicy_ui: "Always"
+```
+
+To configure the image and registry for the user interface, use:
+
+```yaml
+imageName_ui: "s3gw-ui"
+imageTag_ui: "latest"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+# Welcome to the s3gw project
+
+## Project objective
+
+We're building an easy-to-use Open Source and Cloud Native S3 service for
+Kubernetes.
+Our focus is to complement the Rancher portfolio, although the tool isn't
+limited to Rancher products.
+
+## Project priorities
+
+- Complement the Rancher portfolio.
+  - S3 solution for: Longhorn volume, Harvester, Epinio backups. Also OPNI models.
+  - Leverage k3s/k8s and Longhorn for deployment and redundancy, load balancing,
+  etc.
+    - Kubernetes-native management (helm chart, GitOps) and an end-user UI for
+    operations.
+- Single pod deployments (Edge and IoT and smaller on-prem deployments,
+development).
+  - Not a general-purpose scalable S3 data lake.
+  - Scaling would happen via multiple pods serving different instances.
+- We're leveraging the feature-rich S3 gateway from Ceph but without the rest of
+the Ceph stack (no RADOS).
+
+## Summary
+
+In a nutshell, this project provides the required infrastructure to build a container
+able to run on a kubernetes cluster, providing S3-compatible endpoints to
+Kubernetes applications.

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,15 @@
+# License
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use licensed files except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+or the LICENSE file in this repository.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart
+
+## Helm chart
+
+Assuming you've cloned the repo as instructed [here](helm-charts.md):
+
+```shell
+  cd s3gw-charts
+  helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE
+  --create-namespace -f /path/to/your/custom/values.yaml
+```
+
+## Podman
+
+```shell
+podman run --replace --name=s3gw -it -p 7480:7480 ghcr.io/aquarist-labs/s3gw:latest
+```
+
+## Docker
+
+```shell
+docker pull ghcr.io/aquarist-labs/s3gw:latest
+```
+
+In order to run the Docker container:
+
+```shell
+docker run -p 7480:7480 ghcr.io/aquarist-labs/s3gw:latest
+```
+
+For more information on building and running a container, please read our
+[guide](../build/).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,38 @@
+# Roadmap
+
+The aim is to deliver a Minimum Viable Product (MVP). In a nutshell, an MVP
+seeks to collect the maximum amount of validated learning about our users in a
+short time.
+
+Based on the user feedback we collect, we develop features that add up towards
+the goal of delivering the MVP. We're working on phases:
+
+## Phase 1
+
+- Use SQLite as storage backend.
+- Running the s3gw in a container.
+- Be able to run basic S3 operations.
+- Ability to deploy the S3 Gateway on a K8s or K3s cluster with.
+- [Design mockups][1] for User management & an S3 explorer.
+
+---
+
+## Phase 2
+
+- Basic S3 explorer UI
+- Helm chart
+- Define & start work on a file-based backend
+- Implement CI/CD
+
+---
+
+## Phase 3
+
+- File-based backend integration
+- Increased support for S3 functional features
+- S3 explorer UI
+- User management UI
+
+---
+
+[1]: https://www.figma.com/file/IeozuvvYlrKBs7qm030dyo/S3-Wireframe?node-id=0%3A1

--- a/docs/s3-compatibility-table.md
+++ b/docs/s3-compatibility-table.md
@@ -3,29 +3,29 @@
 The following table describes the support status for current Amazon S3
 functional features:
 
-| Feature                   | Status   |
-|---------------------------|----------|
-| List Buckets              | ✅       |
-| Delete Bucket             | ✅       |
-| Create Bucket             | ✅       |
-| Put Object                | ✅       |
-| Delete Object             | ✅       |
-| Get Object                | ✅       |
-| Bucket Lifecycle          |          |
-| Bucket Replication        |          |
-| Policy (Buckets, Objects) |          |
-| Bucket Website            |          |
-| Bucket ACLs (Get, Put)    |          |
-| Bucket Location           |          |
-| Bucket Notification       |          |
-| Bucket Object Versions    |          |
-| Get Bucket Info (HEAD)    |          |
-| Bucket Request Payment    |          |
-| Object ACLs (Get, Put)    |          |
-| Get Object Info (HEAD)    |          |
-| POST Object               |          |
-| Copy Object               |          |
-| Multipart Uploads         |          |
-| Object Tagging            |          |
-| Bucket Tagging            |          |
-| Storage Class             |          |
+| Feature                   | Status |
+| ------------------------- | ------ |
+| List Buckets              | ✅     |
+| Delete Bucket             | ✅     |
+| Create Bucket             | ✅     |
+| Put Object                | ✅     |
+| Delete Object             | ✅     |
+| Get Object                | ✅     |
+| Bucket Lifecycle          |        |
+| Bucket Replication        |        |
+| Policy (Buckets, Objects) |        |
+| Bucket Website            |        |
+| Bucket ACLs (Get, Put)    |        |
+| Bucket Location           |        |
+| Bucket Notification       |        |
+| Bucket Object Versions    |        |
+| Get Bucket Info (HEAD)    |        |
+| Bucket Request Payment    |        |
+| Object ACLs (Get, Put)    |        |
+| Get Object Info (HEAD)    |        |
+| POST Object               |        |
+| Copy Object               |        |
+| Multipart Uploads         |        |
+| Object Tagging            |        |
+| Bucket Tagging            |        |
+| Storage Class             |        |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@ existing gateway running somewhere accessible by the tests. This may be an
 matter whether these running on the local machine or on a remote host, as long
 as they are accessible to the tests.
 
-## smoke tests
+## Smoke tests
 
 Basic test battery to smoke out errors and potential regressions.
 
@@ -20,7 +20,7 @@ we will be able to find the `radosgw`.
 At the moment, these tests mainly rely on `s3cmd`, which requires to be
 installed and available in the `PATH`.
 
-## s3tests
+## S3 tests
 
 Runs a comprehensive test battery against a running `radosgw`. It relies on
 [ceph/s3-tests](https://github.com/ceph/s3-tests), and will clone this
@@ -34,7 +34,7 @@ Each run will be kept in a directory of the form `s3gw-s3test-DATE-TESTID`.
 The cloned `ceph/s3-tests` repository, as well as logs, will be kept within
 this directory.
 
-### creating reports
+### Creating reports
 
 Test reports may be generated using the `create-s3tests-report.sh` script.
 This script requires the resulting log file from an `s3gw-s3tests.sh` run.
@@ -47,7 +47,7 @@ file](https://github.com/aquarist-labs/s3gw-status#readme).)
 
 Please check `create-s3tests-report.sh --help` for more information.
 
-## benchmarking
+## Benchmarking
 
 With tracking our improvement over time in mind, we should be benchmarking
 `radosgw` with the file based backend `simplefile` we have been developing.
@@ -73,7 +73,7 @@ Each time `wrap` is run, a file will be created containing the results of
 the benchmark. This file can later on be used to compare results between runs.
 For more information, please check `warp`'s help.
 
-## stress testing
+## Stress testing
 
 For the purpose of stress testing `s3gw`, you can rely on
 [fio](https://github.com/axboe/fio).
@@ -83,8 +83,8 @@ You can therefore use the tool to issue concurrent and/or serial operations agai
 `s3gw`.
 For a basic stress testing activity you should normally want to shot a series
 of `PUT`(s), `GET`(s) and `DELETE`(s).
-Such workload can be modeled with a fio *jobfile*.
-For example, you can customize the following *jobfile* and tuning it to realize
+Such workload can be modeled with a fio _jobfile_.
+For example, you can customize the following _jobfile_ and tuning it to realize
 the test you wish to perform.
 
 ```ini
@@ -118,7 +118,7 @@ size=16m
 bs=16m
 ```
 
-Once you have created your *jobfile*: `s3gw.fio` you can simply launch
+Once you have created your _jobfile_: `s3gw.fio` you can simply launch
 the workload with:
 
 ```shell
@@ -128,7 +128,7 @@ Starting 9 processes
 ...
 ```
 
-This *jobfile* connects to an S3 gateway listening on `localhost:7480`
+This _jobfile_ connects to an S3 gateway listening on `localhost:7480`
 and operates on a object `obj`
 which resides inside an existing `foo` bucket.
 This example launches 3 types of jobs: `s3-write` (PUT), `s3-read`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,29 @@
+site_name: s3gw Documentationn
+theme:
+  name: readthedocs
+  highlightjs: true
+plugins:
+  - search
+nav:
+  - 'Getting started':
+    - Welcome: 'index.md'
+    - Quickstart: 'quickstart.md'
+  - 'Developing the s3gw':
+    - Developing the S3 Gateway: 'developing.md'
+    - Using a Helm chart: 'helm-charts.md'
+    - Testing the s3gw: 'testing.md'
+    - S3 API compatibility table: 's3-compatibility-table.md'
+  - 'Build a container':
+    - Building the s3gw container image: 'build.md'
+    - Building the s3gw-UI image: 'build-ui.md'
+  - 'Running the s3gw with Longhorn':
+    - K3s Setup: 'env-k3s.md'
+    - K8s Setup: 'env-k8s.md'
+  - 'About & Contributing':
+    - Roadmap: 'roadmap.md'
+    - Repositories: 's3gw-repos.md'
+    - Contributing & reporting: 'contributing.md'
+    - License: 'license.md'
+  - 'Team decisions':
+    - Use Markdown Any Decision Records: 'decisions/0000-use-markdown-any-decision-records.md'
+theme: readthedocs


### PR DESCRIPTION
This PR readthedocs. 

There'll be other PRs for improvements. Here I want to test wether I'm able to deploy the documentation on this URL: https://s3gw-docs.readthedocs.io/en/latest/

It fixes https://github.com/aquarist-labs/s3gw/issues/21 

Signed-off-by: Jesus Herman-Marina <jherman@suse.com>