### PR TITLE
ci: run pre-commit checks as part of linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,16 +1,20 @@
+---
 name: Lint
-on: [push, pull_request, workflow_dispatch]
+on:
+  - push
+  - pull_request
+  - workflow_dispatch
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+
       - name: Set up Git repository
         uses: actions/checkout@v3
-      - name: Codespell
-        uses: codespell-project/actions-codespell@master
-        with:
-          check_filenames: true
-      - name: Markdown
-        uses: DavidAnson/markdownlint-cli2-action@v5
-        with:
-          globs: '**/*.md'
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+
+      - name: Pre-Commit Checks
+        uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Run pre-commit checks as part of linting workflow.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>