### PR TITLE
ci: fold release workflow into single job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,16 +9,8 @@ on:
       - "v*"
 
 jobs:
-  # Figure out which are the refs to be built
-  set-git-refs:
+  release:
     runs-on: ubuntu-latest
-
-    outputs:
-      ceph-git-ref: ${{ steps.git-refs.outputs.ceph }}
-      tools-git-ref: ${{ steps.git-refs.outputs.tools }}
-      ui-git-ref: ${{ steps.git-refs.outputs.ui }}
-      charts-git-ref: ${{ steps.git-refs.outputs.charts }}
-      github-ref-name: ${{ steps.git-refs.outputs.github-ref-name }}
 
     steps:
 
@@ -35,23 +27,19 @@ jobs:
           done
           echo "::set-output name=github-ref-name::${GITHUB_REF_NAME:-nightly}"
 
-  # Build the build-environment container, using it's workflow
-  build-env:
-    uses: aquarist-labs/s3gw-tools/.github/workflows/build-environment.yaml
-    needs: set-git-refs
-    with:
-      tag: ${{ needs.set-git-refs.outputs.github-ref-name }}
-      ref: ${{ needs.set-git-refs.outputs.tools-git-ref }}
+      # Build the build-environment container, using it's workflow
+      - name: Build Environment
+        uses: ./s3gw-tools/.github/workflows/build-environment.yaml
+        with:
+          tag: ${{ steps.git-refs.outputs.github-ref-name }}
+          ref: ${{ steps.git-refs.outputs.tools-git-ref }}
 
-  # Build the radosgw binary using the previously built container image
-  build-radosgw:
-    uses: aquarist-labs/ceph/.github/workflows/build-radosgw.yaml
-    needs:
-      - set-git-refs
-      - build-env
-    with:
-      tag: ${{ needs.set-git-refs.outputs.github-ref-name }}
-      ref: ${{ needs.set-git-refs.outputs.ceph-git-ref }}
+      # Build the radosgw binary using the previously built container image
+      - name: Build Radosgw Binary
+        uses: ./ceph/.github/workflows/build-radosgw.yaml
+        with:
+          tag: ${{ steps.git-refs.outputs.github-ref-name }}
+          ref: ${{ steps.git-refs.outputs.ceph-git-ref }}
 
   # Build and push the radosgw container using the radosgw-binary
   # TODO


### PR DESCRIPTION
Fold the release workflow into a single multi-step job. This is done by
re-using the checked-out version of the subrepos instead of calling the
respective repo's release workflow on the @main branch. Thereby changes
to the respective subrepo don't break the release pipeline of the
overall project

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>