### PR TITLE
feature: add docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,41 @@
+---
+version: "3.4"
+services:
+  s3gw:
+    image: ghcr.io/aquarist-labs/s3gw:latest
+    restart: always
+    command:
+      - "--rgw-backend-store"
+      - "sfs"
+    ports:
+      - "7480:7480"
+    environment:
+      RGW_DEFAULT_USER_ACCESS_KEY: "test"
+      RGW_DEFAULT_USER_SECRET_KEY: "test"
+    volumes:
+      - data:/data
+
+  s3gw-ui:
+    image: ghcr.io/aquarist-labs/s3gw-ui:latest
+    restart: always
+    stop_signal: SIGINT
+    depends_on:
+      - s3gw
+    ports:
+      - "8080:8080"
+    environment:
+      RGW_SERVICE_URL: "http://localhost:3080"
+
+  proxy:
+    image: docker.io/nginx:latest
+    restart: always
+    depends_on:
+      - s3gw-ui
+    ports:
+      - "80:80"
+      - "3080:3080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+
+volumes:
+  data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,32 @@
+server {
+  listen 80;
+  server_name s3gw-ui-proxy;
+
+  location / {
+    proxy_pass http://s3gw-ui:8080/;
+  }
+}
+
+server {
+  listen 3080;
+  server_name s3gw-proxy;
+
+  location / {
+
+    if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Headers' '*';
+      add_header 'Access-Control-Allow-Methods' 'DELETE,GET,HEAD,POST,PUT';
+      add_header 'Content-Type' 'application/json';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
+
+    add_header 'Access-Control-Allow-Origin' '*' always;
+    add_header 'Access-Control-Allow-Headers' '*' always;
+    add_header 'Access-Control-Allow-Methods' 'DELETE,GET,HEAD,POST,PUT' always;
+
+    proxy_pass http://s3gw:7480/;
+  }
+}


### PR DESCRIPTION
Add docker-compose file for easy local deployment of the s3gw and the ui
with minimal runtime requirements.

Requires docker and docker-compose. Should be compatible with docker
swarm, but has not been tested.

This allows users without access to a kubernetes cluster to quickly
deploy the s3gw including ui by simply executing:

```
docker-compose up
```

fixes: #74
Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>