### PR TITLE
Adds templates for issues & PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/backlog_item.md
+++ b/.github/ISSUE_TEMPLATE/backlog_item.md
@@ -1,0 +1,15 @@
+---
+name: Backlog item
+about: Template used internally for new features
+title: "[Backlog] "
+labels: "backlog"
+assignees: ""
+---
+
+### What needs to be done
+
+### Why it needs to be done
+
+### Acceptance Criteria
+
+### Additional Information

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: "bug"
+assignees: ""
+---
+
+**Describe the bug** A clear and concise description of what the bug is.
+
+**To Reproduce** Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior** A clear and concise description of what you expected to
+happen.
+
+**Screenshots** If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context** Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FR] "
+labels: "feature"
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.** A clear and
+concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like** A clear and concise description of what you
+want to happen.
+
+**Describe alternatives you've considered** A clear and concise description of
+any alternative solutions or features you've considered.
+
+**Additional context** Add any other context or screenshots about the feature
+request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Describe your changes
+
+## Issue ticket number and link
+
+## Checklist before requesting a review
+
+- [ ] I have performed a self-review of my code.
+- [ ] If it is a core feature, I have added thorough tests.
+- [ ] Will this be part of a product update? If yes, please write one phrase
+      about this update.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+.DS_Store


### PR DESCRIPTION
## Changes

This PR introduces 3 new templates:

* PR
* Bug report template
* Feature request for external stakeholders
* Internal template for new backlog issues

Related issue: https://github.com/aquarist-labs/s3gw/issues/22

The PR template will also need to be implemented in the charts & tools repo. The ceph repo has its own.

## Rationale

After researching, I opted for implementing templates similar to those used in [Rancher products](https://github.com/rancher/rancher/tree/release/v2.6/.github). It didn't make sense to reinvent the wheel 😄.

## Feedback 

All comments are welcome. There are probably things that could be improved in these templates 👍 

Signed-off-by: Jesus Herman-Marina <jherman@suse.com>