### PR TITLE
ci: pass credentials to s3gw-tools workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,8 @@ jobs:
     with:
       tag: ${{ needs.set-git-refs.outputs.github-ref-name }}
       ref: ${{ needs.set-git-refs.outputs.tools-git-ref }}
+      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
 #   # Build the radosgw binary using the previously built container image
 #   build-radosgw:


### PR DESCRIPTION
Pass dockerhub credentials to s3gw-tools workflow during workflow call.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>