### PR TITLE
ci: use secret inherittance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,7 @@ jobs:
     with:
       tag: ${{ needs.set-git-refs.outputs.github-ref-name }}
       ref: ${{ needs.set-git-refs.outputs.tools-git-ref }}
-      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+    secrets: inherit
 
 #   # Build the radosgw binary using the previously built container image
 #   build-radosgw:


### PR DESCRIPTION
Secrets can not be passed explicitly as normal parameters, but the called workflow can inherit secrets from the caller.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>