### PR TITLE
ci: disable nightly release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 ---
 name: Release S3GW
 on:
-  schedule:
-    - cron: '30 4 * * 1-6'  # Every night 4:30 except sunday
-
   push:
     tags:
       - "v*"
@@ -32,8 +29,7 @@ jobs:
           for r in $(git submodule | awk '{print $2}'); do
             echo "::set-output name=${r}::$(git log -1 --format="%H" "${r}")"
           done
-          echo "::set-output name=github-ref-name::${GITHUB_REF_NAME:-nightly}"
-
+          echo "::set-output name=github-ref-name::${GITHUB_REF_NAME}"
 
   # Build the build-environment container, using it's workflow
   build-env:


### PR DESCRIPTION
Disable nightly release to avoid clobbering the proper releases.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

This can be reverted if needed, but at the moment we have little benefit from it and it messes with the containers in an unexpected way (latest wouldn't point to the latest release anymore).

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
