### PR TITLE
docs: revise helm install procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # s3gw
 
-![License](https://img.shields.io/github/license/aquarist-labs/s3gw)
-![Issues](https://img.shields.io/github/issues/aquarist-labs/s3gw)
-![Lint](https://github.com/aquarist-labs/s3gw/actions/workflows/lint.yaml/badge.svg)
-![Build][5]
-[![Artifact Hub][4]][3]
+[![License][license-badge]][license-link]
+[![Documentation Status][docs-badge]][docs-link]
+[![Issues][issues-badge]][issues-link]
+[![Lint][linter-badge]][linter-link]
+[![Build][build-badge]][build-link]
+[![Artifact Hub][chart-badge]][chart-link]
 
 We're developing an easy-to-use Open Source and Cloud Native S3 service for
 Kubernetes.
@@ -62,6 +63,15 @@ limitations under the License.
 
 [1]: https://github.com/aquarist-labs/s3gw-charts
 [2]: https://s3gw-docs.readthedocs.io/en/latest/
-[3]: https://artifacthub.io/packages/search?repo=s3gw
-[4]: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/s3gw
-[5]: https://github.com/aquarist-labs/s3gw/actions/workflows/release.yaml/badge.svg
+[build-badge]: https://github.com/aquarist-labs/s3gw/actions/workflows/release.yaml/badge.svg
+[build-link]: https://github.com/aquarist-labs/s3gw/releases
+[chart-badge]: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/s3gw
+[chart-link]: https://artifacthub.io/packages/search?repo=s3gw
+[docs-badge]: https://readthedocs.org/projects/s3gw-docs/badge/?version=latest
+[docs-link]: https://s3gw-docs.readthedocs.io/en/latest/?badge=latest
+[issues-badge]: https://img.shields.io/github/issues/aquarist-labs/s3gw
+[issues-link]: https://github.com/aquarist-labs/s3gw/issues
+[license-badge]: https://img.shields.io/github/license/aquarist-labs/s3gw
+[license-link]: https://github.com/aquarist-labs/s3gw/blob/main/LICENSE
+[linter-badge]: https://github.com/aquarist-labs/s3gw/actions/workflows/lint.yaml/badge.svg
+[linter-link]: https://github.com/aquarist-labs/s3gw/actions/workflows/lint.yaml

--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -1,21 +1,30 @@
 # Installation and options
 
-In order to install s3gw using Helm, from this repository directly, first you
-must clone the repo:
+The canonical way to install the helm chart is via a helm repository:
 
 ```bash
-  git clone https://github.com/aquarist-labs/s3gw-charts.git
+helm repo add s3gw https://aquarist-labs.github.io/s3gw-charts/
+helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE \
+  --create-namespace -f /path/to/your/custom/values.yaml
+```
+
+The chart can also be installed directly from the git repository. To do so, the
+repo must be cloned first:
+
+```bash
+git clone https://github.com/aquarist-labs/s3gw-charts.git
+```
+
+And then the chart can be installed from within the repo directory:
+
+```bash
+cd s3gw-charts
+helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE \
+  --create-namespace -f /path/to/your/custom/values.yaml
 ```
 
 Before installing, familiarize yourself with the options, if necessary provide
-your own `values.yaml` file. Then change into the repository and install using
-helm:
-
-```bash
-  cd s3gw-charts
-  helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE
-  --create-namespace -f /path/to/your/custom/values.yaml
-```
+your own `values.yaml` file.
 
 ## Rancher
 
@@ -44,6 +53,17 @@ ingress controller.
 The helm chart can be customized for your Kubernetes environment. To do so,
 either provide a `values.yaml` file with your settings, or set the options on
 the command line directly using `helm --set key=value`.
+
+### Access Credentials
+
+It is strongly advisable to customize the initial access credentials.
+These can be used to access the admin UI, as well as the S3 endpoint. Additional
+credentials can be created using the admin UI.
+
+```yaml
+accessKey: admin
+secretKey: foobar
+```
 
 ### Hostname
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,11 +2,12 @@
 
 ## Helm chart
 
-Assuming you've cloned the repo as instructed [here](helm-charts.md):
+Add the helm chart to your helm repos and install from there. There are [several
+options][1] for customization.
 
 ```shell
-  cd s3gw-charts
-  helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE
+helm repo add s3gw https://aquarist-labs.github.io/s3gw-charts/
+helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE \
   --create-namespace -f /path/to/your/custom/values.yaml
 ```
 
@@ -30,3 +31,5 @@ docker run -p 7480:7480 ghcr.io/aquarist-labs/s3gw:latest
 
 For more information on building and running a container, please read our
 [guide](../developing/#how-to-build-your-own-containers/).
+
+[1]: https://github.com/aquarist-labs/s3gw/blob/main/docs/helm-charts.md#options


### PR DESCRIPTION
- Revise helm based installation in quickstart guide
- Improve badges in the readme

Revised helm install procedure for quickstart guide. Since the chart is now published as helm repo, installation from the git repo is no longer the easiest way. This change describes the easier way to install a helm chart via helm's repo command.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
