### PR TITLE
adr: Add instruction for release captain

### DIFF
--- a/docs/decisions/0004-release-captain.md
+++ b/docs/decisions/0004-release-captain.md
@@ -1,10 +1,11 @@
 # Context and Problem Statement
 
 We want to share the responsibility of release management. Each week of the
-release, one team member will be responsible for all release-related tasks.
-This team member will be the release captain.
+release, one team member will be responsible for all release-related tasks. This
+team member will be the release captain.
 
-This document defines and agrees on the responsibilities of said release captain.
+This document defines and agrees on the responsibilities of said release
+captain.
 
 ## Considered Options
 
@@ -12,22 +13,24 @@ This document defines and agrees on the responsibilities of said release captain
 
 The release captain is responsible for the content of a release. That means
 taking appropriate measures to include all necessary fixes and features as well
-as delivering sane and functional container images.
-The release captain is also responsible for describing the changes of the new
-release in the release notes.
+as delivering sane and functional container images. The release captain is also
+responsible for describing the changes of the new release in the release notes.
 
 ### Create a Release
 
-- Bump versions in Chart (in values.yaml _and_ in Chart.yaml)
-- Aggregate change log and create s3gw/docs/release-notes/s3gw-vx.x.x.md
-  Use previous release notes for guidance.
-- Change s3gw/docs/release-notes/latest to point to the new release notes
-  (this will be used by automation)
+- Create a release branch for a given release for the `ceph` & `s3gw-ui`
+  repositories. All bugfixes will be backported to the relevant repo. The name
+  of the branch should reflect the current milestone (ie `0.8.0`). In the Ceph
+  repo we need to prepend `s3gw-`(ie `s3gw-0.8.0`)
+- Aggregate changelog and create s3gw/docs/release-notes/s3gw-vx.x.x.md Use
+  previous release notes for guidance.
+- Change s3gw/docs/release-notes/latest to point to the new release notes (this
+  will be used by automation)
+- Update all subrepos changelog from `Unreleased` to the current release date.
 - Bump all subrepos repos to the desired git ref
 - Push these changes
-- Create a version tag in the s3gw repo
-  (this triggers the release pipeline, which creates the container and a draft
-  release)
+- Create a version tag in the s3gw repo (this triggers the release pipeline,
+  which creates the container and a draft release)
 - After waiting for the release pipeline to finish building, go to the release
   page and make the release public
 
@@ -35,8 +38,11 @@ release in the release notes.
 
 - s3gw container published (ghcr.io/aquarist-labs/s3gw:vx.x.x)
 - s3gw-ui container published (ghcr.io/aquarist-labs/s3gw-ui:vx.x.x)
-- chart updated
-- release notes
+- The container tags ghcr.io/aquarist-labs/s3gw:latest and
+  ghcr.io/aquarist-labs/s3gw-ui:latest should exist and point to their
+  respective latest container.
+- Chart updated
+- Release notes
 
 ## Decision Outcome
 


### PR DESCRIPTION
# Describe your changes

This PR adds an instruction for the release captain on updating the changelogs from `Unreleased` to the release date.

## Issue ticket number and link

No issue number. This comes from a conversation we had on Slack.

⚠️ This change will be reverted once generating the [changelog is fully automated](https://github.com/aquarist-labs/s3gw/issues/149).

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.

Signed-off-by: Jesus Herman-Marina <jherman@suse.com>