### PR TITLE
docs: Update rancher instructions and change addresses

### DIFF
--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -32,13 +32,11 @@ Installing s3gw via the Rancher App Catalog is made easy, the steps are as
 follow
 
 - Cluster -> Projects/Namespaces - create the `s3gw` namespace.
-- Storage -> PersistentVolumeClaim -> Create -> choose the `s3gw` namespace ->
-  provide a size and name it `s3gw-pvc`.
 - Apps -> Repositories -> Create `s3gw` using the s3gw-charts Git URL
-  <https://github.com/aquarist-labs/s3gw-charts> and the main branch.
+  <https://aquarist-labs.github.io/s3gw-charts/> and the main branch.
 - Apps -> Charts -> Install Traefik.
-- Apps -> Charts -> Install `s3gw` -> Storage -> Storage Type: `pvc` -> PVC
-  Name: `s3gw-pvc`.
+- Apps -> Charts -> Install `s3gw`. Select the `s3gw` namespace previously created.
+  This will create a `pvc` for `s3gw`.
 
 ## Dependencies
 

--- a/docs/s3gw-with-k8s-k3s.md
+++ b/docs/s3gw-with-k8s-k3s.md
@@ -181,10 +181,6 @@ allocated on a separate virtual host:
 - **s3gw**, on: `s3gw.local` and `s3gw-no-tls.local`
 - **s3gw s3 explorer**, on: `s3gw-ui.local` and `s3gw-ui-no-tls.local`
 
-Host names are exposed with a node port service listening on ports 30443 (https)
-and 30080 (http). You are required to resolve these names with the external ip
-of one of the nodes of the cluster.
-
 When you are running the cluster on a virtual machine, you can patch host's
 `/etc/hosts` file as follows:
 
@@ -203,11 +199,11 @@ follows:
 Services can now be accessed at:
 
 ```text
-https://longhorn.local:30443
-https://s3gw.local:30443
-http://s3gw-no-tls.local:30080
-https://s3gw-ui.local:30443
-http://s3gw-ui-no-tls.local:30080
+https://longhorn.local
+https://s3gw.local
+http://s3gw-no-tls.local
+https://s3gw-ui.local
+http://s3gw-ui-no-tls.local
 ```
 
 ### K3s on Bare Metal


### PR DESCRIPTION
This changes the instructions when installing with `Rancher` and also changes the addresses to access `s3gw` and `s3gw-ui`.

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>
