### PR TITLE
doc: unify commit signing requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ specific as possible. If the commit message title was too short to fully state
 what the commit is doing, use the body to explain not just the "what", but also
 the "why".
 
-Finally, it _must_ include a `Signed-off-by:` line matching an email address of
+Your commit _must_ include a `Signed-off-by:` line matching an email address of
 the commit's author to comply with our need for a
 [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The
 DCO is a lightweight way for contributors to certify that they wrote or
@@ -89,6 +89,8 @@ For example:
 
    Signed-off-by: Random Developer <random@developer.io>
 ```
+
+Finally, please be sure to sign all commits with your GPG key (`git commit -S`).
 
 ## Pull Requests
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,6 +11,7 @@ yet, or to contribute with further details to an existing issue.
 
 - If the PR fixes a GitHub issue, then add the line `Fixes: https://github.com/aquarist-labs/s3gw/issues/<ISSUE_NR>`
   to the Git commit message.
+- Make sure your Git commit includes a `Signed-off-by:` line.
 - Make sure your Git commit is signed with a GPG key.
 - Include unit tests if possible.
 - Append a line to the CHANGELOG.md of the corresponding GH project. If the
@@ -25,5 +26,5 @@ We track our progress in this [Github project][2] board.
 You can join us in [Slack][3].
 
 [1]: https://github.com/aquarist-labs/s3gw/issues
-[2]: https://join.slack.com/t/aquaristlabs/shared_invite/zt-nphn0jhg-QYKw__It8JPMkUR_sArOug
-[3]: https://github.com/orgs/aquarist-labs/projects/5/views/1
+[2]: https://github.com/orgs/aquarist-labs/projects/5/views/1
+[3]: https://join.slack.com/t/aquaristlabs/shared_invite/zt-nphn0jhg-QYKw__It8JPMkUR_sArOug


### PR DESCRIPTION
CONTRIBUTING.md and docs/contributing.md had slightly different information, so I've made sure that both mention the need to have a Signed-off-by line, and the need to GPG sign commits.  I've also fixed the project board and slack links which were transposed.

Signed-off-by: Tim Serong <tserong@suse.com>