### PR TITLE
docs: add the contributing guides to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 venv
 .DS_Store
+.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,15 @@ We welcome new feature implementations, patches that fix bugs or code cleanup.
 
 You can clone from GitHub with:
 
+```bash
 git clone git@github.com:aquarist-labs/s3gw-tools
+```
 
 Or:
 
+```bash
 git clone git://github.com/aquarist-labs/s3gw-tools
+```
 
 This applies to all the repositories.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,30 +1,3 @@
-# Contributing
-
-## Reporting an issue
-
-If one finds a problem, as one is bound to at this point in time, we encourage
-everyone to check out our [issues list][1]
-and either file a new issue if the observed behavior has not been reported
-yet, or to contribute with further details to an existing issue.
-
-## Pull request prerequisites
-
-- If the PR fixes a GitHub issue, then add the line `Fixes: https://github.com/aquarist-labs/s3gw/issues/<ISSUE_NR>`
-  to the Git commit message.
-- Make sure your Git commit includes a `Signed-off-by:` line.
-- Make sure your Git commit is signed with a GPG key.
-- Include unit tests if possible.
-- Append a line to the CHANGELOG.md of the corresponding GH project. If the
-  PR references an issue, then please also add the comment `(gh#aquarist-labs/s3gw#<ISSUE_NR>)`.
-
-## Project Board
-
-We track our progress in this [Github project][2] board.
-
-## Discussion
-
-You can join us in [Slack][3].
-
-[1]: https://github.com/aquarist-labs/s3gw/issues
-[2]: https://github.com/orgs/aquarist-labs/projects/5/views/1
-[3]: https://join.slack.com/t/aquaristlabs/shared_invite/zt-nphn0jhg-QYKw__It8JPMkUR_sArOug
+<!-- markdownlint-disable MD013 -->
+<!-- markdownlint-disable MD041 -->
+{{ external_markdown('https://raw.githubusercontent.com/aquarist-labs/s3gw/main/CONTRIBUTING.md', '') }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ theme:
   highlightjs: true
 plugins:
   - search
+  - external-markdown
 nav:
   - Introduction: "index.md"
   - Quickstart: "quickstart.md"


### PR DESCRIPTION
Signed-off-by: Jesus Herman-Marina <jherman@suse.com>

# Describe your changes

This PR implements a mkdocs plugin that renders a page taking content from another page. In this case it's injecting the content from `CONTRIBUTING.md `into` docs/contributing.md`

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
