### PR TITLE
ci: release workflow push to quay.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,12 +149,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: GHCR Login
+      - name: Quay Login
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Download Radogw Artifacts
         uses: actions/download-artifact@v3
@@ -170,8 +170,8 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/s3gw:${{ needs.set-git-refs.outputs.github-ref-name }}
-            ghcr.io/${{ github.repository_owner }}/s3gw:latest
+            quay.io/s3gw/s3gw:${{ needs.set-git-refs.outputs.github-ref-name }}
+            quay.io/s3gw/s3gw:latest
           file: tools/build/Dockerfile.build-container
           context: ceph/build
 
@@ -194,20 +194,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: GHCR Login
+      - name: Quay Login
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and Push Container
         uses: docker/build-push-action@v3
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/s3gw-ui:${{ needs.set-git-refs.outputs.github-ref-name }}
-            ghcr.io/${{ github.repository_owner }}/s3gw-ui:latest
+            quay.io/s3gw/s3gw-ui:${{ needs.set-git-refs.outputs.github-ref-name }}
+            quay.io/s3gw/s3gw-ui:latest
           file: ui/Dockerfile
           context: ui
 


### PR DESCRIPTION
- Make the release workflow push to quay.io instead of ghcr.io

All future releases from this point on will be pushed to quay.io instead of ghcr.io. There will not be container images pushed to ghcr.io anymore. Quay.io offers better usage and download reports, which are important to judge user adoption.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
