### PR TITLE
ci: add nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,156 @@
+---
+name: Nightly Builds
+
+on:
+  schedule:
+    cron: '0 0 * * *'  # Every night midnight
+
+  workflow_dispatch:   # Or manually - for testing
+
+jobs:
+  # Build the build-environment container, using it's workflow
+  build-env:
+    runs-on: ubuntu-latest
+    needs:
+      - set-git-refs
+
+    outputs:
+      date: ${{ steps.date.outputs.date }}
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Dockerhub Login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate Date String
+        id: date
+        run: |
+          DATE="$(date +%Y-%m-%d)"
+          echo "date=${DATE}" >> $GITHUB_OUTPUT
+
+      - name: Build Buildenv Container
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/buildenv-radosgw:nightly-${{ steps.date.outputs.date }}
+          file: tools/build/Dockerfile.build-radosgw
+          context: tools/build
+
+  # Build the radosgw binary using the previously built container image
+  build-radosgw:
+    runs-on: ubuntu-latest
+    needs:
+      - build-env
+
+    outputs:
+      artifact_id: ${{ steps.artifact_id.outputs.artifact_id }}
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: aquarist-labs/ceph
+          ref: s3gw
+          submodules: recursive
+          path: ceph
+
+      - name: Cache CCache Files
+        uses: actions/cache@v3.0.4
+        with:
+          path: ceph/build.ccache
+          key: ccache-${{ needs.build-env.outputs.date }}
+          restore-keys: |
+            ccache-
+
+      - name: Build radosgw Binary
+        run: |
+          docker run --rm \
+            -v $GITHUB_WORKSPACE/ceph:/srv/ceph \
+            -e NPROC=4 \
+            -e CMAKE_BUILD_TYPE=Release \
+            ${{ secrets.DOCKERHUB_USERNAME }}/buildenv-radosgw:nightly-${{ needs.build-env.outputs.date }}
+
+      - name: Compress Build Results
+        run: |
+          tar -czvf build-results.tar.gz \
+            ceph/build/bin/radosgw \
+            ceph/build/lib/libceph-common.so \
+            ceph/build/lib/libceph-common.so.2 \
+            ceph/build/lib/libradosgw.so \
+            ceph/build/lib/libradosgw.so.2 \
+            ceph/build/lib/libradosgw.so.2.0.0 \
+            ceph/build/lib/librados.so \
+            ceph/build/lib/librados.so.2 \
+            ceph/build/lib/librados.so.2.0.0
+
+      - name: Generate Artifact Identifier
+        id: artifact_id
+        run: |
+          ARTIFACT_ID=radosgw-nightly-${{ needs.build-env.outputs.date }}
+          echo "artifact_id=$ARTIFACT_ID" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.artifact_id.outputs.artifact_id }}
+          path: build-results.tar.gz
+
+  # Build and push the radosgw container using the radosgw-binary
+  build-s3gw-container:
+    runs-on: ubuntu-latest
+    needs:
+      - build-env
+      - build-radosgw
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Quay Login
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Download Radogw Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build-radosgw.outputs.artifact_id }}
+
+      - name: Unpack Artifacts
+        run: |
+          tar -xvf build-results.tar.gz
+
+      - name: Build S3GW Container
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: |
+            quay.io/s3gw/s3gw:nightly-${{ needs.build-env.outputs.date }}
+            quay.io/s3gw/s3gw:nightly-latest
+          file: tools/build/Dockerfile.build-container
+          context: ceph/build

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,20 +33,20 @@ jobs:
       - name: Dockerhub Login
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Generate Date String
+      - name: Generate Tag based on Date
         id: date
         run: |
           DATE="$(date +%Y-%m-%d)"
-          echo "date=${DATE}" >> $GITHUB_OUTPUT
+          echo "tag=nightly-${DATE}" >> $GITHUB_OUTPUT
 
       - name: Build Buildenv Container
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/buildenv-radosgw:nightly-${{ steps.date.outputs.date }}
+          tags: quay.io/s3gw/buildenv-radosgw:${{ steps.date.outputs.tag}}
           file: tools/build/Dockerfile.build-radosgw
           context: tools/build
 
@@ -79,11 +79,12 @@ jobs:
 
       - name: Build radosgw Binary
         run: |
+          TAG=nightly-${{ needs.build-env.outputs.date }}
           docker run --rm \
             -v $GITHUB_WORKSPACE/ceph:/srv/ceph \
             -e NPROC=4 \
             -e CMAKE_BUILD_TYPE=Release \
-            ${{ secrets.DOCKERHUB_USERNAME }}/buildenv-radosgw:nightly-${{ needs.build-env.outputs.date }}
+            quay.io/s3gw/buildenv-radosgw:${{ needs.build-env.outputs.tag }}
 
       - name: Compress Build Results
         run: |
@@ -101,7 +102,7 @@ jobs:
       - name: Generate Artifact Identifier
         id: artifact_id
         run: |
-          ARTIFACT_ID=radosgw-nightly-${{ needs.build-env.outputs.date }}
+          ARTIFACT_ID=radosgw-${{ needs.build-env.outputs.tag }}
           echo "artifact_id=$ARTIFACT_ID" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
@@ -150,7 +151,7 @@ jobs:
         with:
           push: true
           tags: |
-            quay.io/s3gw/s3gw:nightly-${{ needs.build-env.outputs.date }}
+            quay.io/s3gw/s3gw:${{ needs.build-env.outputs.tag }}
             quay.io/s3gw/s3gw:nightly-latest
           file: tools/build/Dockerfile.build-container
           context: ceph/build


### PR DESCRIPTION
- Add build workflow for nightly container builds from latest HEAD of aquarist-labs/ceph@s3gw branch.
- Push to quay.io and with nightly-$(date) tag and update floating nightly-latest tag

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>


- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
