### PR TITLE
ci: fix nightly build syntax

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,7 +3,7 @@ name: Nightly Builds
 
 on:
   schedule:
-    cron: '0 0 * * *'  # Every night midnight
+    - cron: '0 0 * * *'  # Every night midnight
 
   workflow_dispatch:   # Or manually - for testing
 


### PR DESCRIPTION
GH actions require that the `schedule` trigger has a list of objects with the `cron` key, instead of just a key named `cron`.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
