### PR TITLE
ci: nightly - remove references to set-git-refs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,8 +11,6 @@ jobs:
   # Build the build-environment container, using it's workflow
   build-env:
     runs-on: ubuntu-latest
-    needs:
-      - set-git-refs
 
     outputs:
       date: ${{ steps.date.outputs.date }}


### PR DESCRIPTION
The nightly pipeline doesn't need the set-git-refs job anymore. Remove all references to it as it'll break the pipeline

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
