### PR TITLE
ci: nightly builds log into quay.io

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: Dockerhub Login
         uses: docker/login-action@v1
         with:
+          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 


### PR DESCRIPTION
Log into quay.io, not dockerhub to authorize for pushing the build container.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
