### PR TITLE
ci: nightly pipeline build-env outputs the tag

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      date: ${{ steps.date.outputs.date }}
+      tag: ${{ steps.date.outputs.tag }}
 
     steps:
 
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: quay.io/s3gw/build-radosgw:${{ steps.date.outputs.tag}}
+          tags: quay.io/s3gw/build-radosgw:${{ steps.date.outputs.tag }}
           file: tools/build/Dockerfile.build-radosgw
           context: tools/build
 
@@ -72,13 +72,13 @@ jobs:
         uses: actions/cache@v3.0.4
         with:
           path: ceph/build.ccache
-          key: ccache-${{ needs.build-env.outputs.date }}
+          key: ccache-${{ needs.build-env.outputs.tag }}
           restore-keys: |
             ccache-
 
       - name: Build radosgw Binary
         run: |
-          TAG=nightly-${{ needs.build-env.outputs.date }}
+          TAG=nightly-${{ needs.build-env.outputs.tag }}
           docker run --rm \
             -v $GITHUB_WORKSPACE/ceph:/srv/ceph \
             -e NPROC=4 \


### PR DESCRIPTION
The buildenv job outputs the tag, not just the date. Adjust the rest of the pipeline by renaming date to tag where necessary.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
