### PR TITLE
ci: release pipeline, drop libradosgw

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,9 +111,6 @@ jobs:
             ceph/build/bin/radosgw \
             ceph/build/lib/libceph-common.so \
             ceph/build/lib/libceph-common.so.2 \
-            ceph/build/lib/libradosgw.so \
-            ceph/build/lib/libradosgw.so.2 \
-            ceph/build/lib/libradosgw.so.2.0.0 \
             ceph/build/lib/librados.so \
             ceph/build/lib/librados.so.2 \
             ceph/build/lib/librados.so.2.0.0


### PR DESCRIPTION
Drop libradosgw shared object files from release pipeline. These are now statically linked due to upstream Ceph build system changes.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
