### PR TITLE
ci: remove libradosgw from nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -91,9 +91,6 @@ jobs:
             ceph/build/bin/radosgw \
             ceph/build/lib/libceph-common.so \
             ceph/build/lib/libceph-common.so.2 \
-            ceph/build/lib/libradosgw.so \
-            ceph/build/lib/libradosgw.so.2 \
-            ceph/build/lib/libradosgw.so.2.0.0 \
             ceph/build/lib/librados.so \
             ceph/build/lib/librados.so.2 \
             ceph/build/lib/librados.so.2.0.0


### PR DESCRIPTION
libradosgw is no longer a build target. Remove it from the nightly builds and the archive with generated build artifacts.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
