### PR TITLE
ci: build-environment triggers and fixes

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -5,18 +5,12 @@ on:
     branches:
       - "main"
 
-  workflow_call:
-    inputs:
-      tag:
-        description: "A tag to use for the container image."
-        required: false
-        type: string
-        default: "latest"
-      ref:
-        description: "The git ref to checkout and build."
-        required: false
-        default: "main"
-        type: string
+    # Only run this if the respective Dockerfiles have changed
+    paths:
+      - "tools/build/*"
+
+    workflow_dispatch:  # Allow this workflow to be triggered manually
+
 
 jobs:
   build:
@@ -35,21 +29,17 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Build image ${{ matrix.dockerfile }}
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
+      - name: Registry Login
+        uses: docker/login-action@v1
         with:
-          image: 's3gw/${{ matrix.dockerfile }}'
-          tags: latest ${{ github.sha }}
-          containerfiles: 'tools/build/Dockerfile.${{ matrix.dockerfile }}'
-          context: 'tools/build'
-
-      - name: Push build-radosgw to quay.io
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build image ${{ matrix.dockerfile }}
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: quay.io/s3gw/${{ matrix.dockerfile }}:latest ${{ github.sha }}
+          file: 'tools/build/Dockerfile.${{ matrix.dockerfile }}'
+          context: 'tools/build'


### PR DESCRIPTION
- Use docker actions with login to ensure authentication succeeds for the push of the container images to quay.io
- Allow manually triggering the workflow
- Build the environments only on changes to the respective source files otherwise

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
