### PR TITLE
ci: fix build-environment trigger

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -9,8 +9,7 @@ on:
     paths:
       - "tools/build/*"
 
-    workflow_dispatch:  # Allow this workflow to be triggered manually
-
+  workflow_dispatch:  # Allow this workflow to be triggered manually
 
 jobs:
   build:


### PR DESCRIPTION
Fix the indentation for the `workflow_dispatch` trigger of the build-environment workflow.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
