### PR TITLE
ci: fix build environment container tags

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -39,6 +39,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: quay.io/s3gw/${{ matrix.dockerfile }}:latest ${{ github.sha }}
+          tags:
+            - quay.io/s3gw/${{ matrix.dockerfile }}:latest
+            - quay.io/s3gw/${{ matrix.dockerfile }}:${{ github.sha }}
           file: 'tools/build/Dockerfile.${{ matrix.dockerfile }}'
           context: 'tools/build'


### PR DESCRIPTION
Fix tagging for the build environment containers. Both the `latest` tag as well as the commit sha will be used, because this makes it easier to go back to specific environments for testing.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
