### PR TITLE
ci: fix stupid input to GH action

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -39,8 +39,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags:
-            - quay.io/s3gw/${{ matrix.dockerfile }}:latest
-            - quay.io/s3gw/${{ matrix.dockerfile }}:${{ github.sha }}
+          tags: |
+            quay.io/s3gw/${{ matrix.dockerfile }}:latest
+            quay.io/s3gw/${{ matrix.dockerfile }}:${{ github.sha }}
           file: 'tools/build/Dockerfile.${{ matrix.dockerfile }}'
           context: 'tools/build'


### PR DESCRIPTION
Fix `List` type input for field `tags` for docker-build-push action, because instead of just using the YAML `List` type, it has to be new-line separated strings - obviously.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
