### PR TITLE
Fix (relative) path to s3gw-ui Git repository.

### DIFF
--- a/tools/build-ui/build.sh
+++ b/tools/build-ui/build.sh
@@ -4,7 +4,7 @@ set -e
 
 BUILDER_IMAGE_NAME=${BUILDER_IMAGE_NAME:-"s3gw-ui-builder"}
 IMAGE_NAME=${IMAGE_NAME:-"s3gw-ui"}
-S3GW_UI_DIR=$(realpath ${S3GW_UI_DIR:-"../../s3gw-ui/"})
+S3GW_UI_DIR=$(realpath ${S3GW_UI_DIR:-"../../../s3gw-ui/"})
 S3GW_UI_DIST_DIR=${S3GW_UI_DIST_DIR:-"${S3GW_UI_DIR}/dist/s3gw-ui/"}
 
 force=false


### PR DESCRIPTION
Because of the relocation to the `s3gw` repository, the tools directory is one directory lower.

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
