### PR TITLE
ci: build environment using buildx

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -8,6 +8,7 @@ on:
     # Only run this if the respective Dockerfiles have changed
     paths:
       - "tools/build/*"
+      - ".github/workflows/build-environment.yaml"
 
   workflow_dispatch:  # Allow this workflow to be triggered manually
 
@@ -23,20 +24,25 @@ jobs:
           - build-run-radosgw-tests
 
     steps:
+
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Registry Login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build image ${{ matrix.dockerfile }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: |


### PR DESCRIPTION
- Update docker actions to latest version
- Use buildx for building instead of vanilla docker
- Trigger rebuilding the images also when the workflow for that changes

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
