### PR TITLE
ci: rebuild build environments weekly

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -1,6 +1,9 @@
 ---
 name: Build Environment
 on:
+  schedule:
+    - cron: '0 0 * * 0'  # Every sunday night midnight
+
   push:
     branches:
       - "main"


### PR DESCRIPTION
Add GitHub trigger to rebuild build/runtime environments weekly, every sunday night.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
