### PR TITLE
ci: on-disk format checker and release tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,37 +6,9 @@ on:
       - "v*"
 
 jobs:
-  set-git-refs:
-    runs-on: ubuntu-latest
-
-    outputs:
-      ceph-git-ref: ${{ steps.git-refs.outputs.ceph }}
-      tools-git-ref: ${{ steps.git-refs.outputs.tools }}
-      ui-git-ref: ${{ steps.git-refs.outputs.ui }}
-      charts-git-ref: ${{ steps.git-refs.outputs.charts }}
-      github-ref-name: ${{ steps.git-refs.outputs.github-ref-name }}
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Set Git Refs
-        id: git-refs
-        run: |
-          for r in $(git submodule | awk '{print $2}'); do
-            echo "${r}=$(git log -1 --format=\"%H\" \"${r}\")" >> $GITHUB_OUTPUT
-          done
-          echo "github-ref-name=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
-
   # Build the build-environment container, using it's workflow
   build-env:
     runs-on: ubuntu-latest
-    needs:
-      - set-git-refs
-
     steps:
 
       - name: Checkout
@@ -51,16 +23,16 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Dockerhub Login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build Buildenv Container
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/buildenv-radosgw:${{ needs.set-git-refs.outputs.github-ref-name }}
+          tags: quay.io/s3gw/build-radosgw:${{ vars.GITHUB_REF_NAME }}
           file: tools/build/Dockerfile.build-radosgw
           context: tools/build
 
@@ -68,7 +40,6 @@ jobs:
   build-radosgw:
     runs-on: ubuntu-latest
     needs:
-      - set-git-refs
       - build-env
 
     outputs:
@@ -77,10 +48,14 @@ jobs:
     steps:
 
       - name: Checkout
+        with:
+          path: s3gw
+
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           repository: aquarist-labs/ceph
-          ref: ${{ needs.outputs.ceph-git-ref }}
+          ref: s3gw-${{ vars.GITHUB_REF_NAME }}
           submodules: recursive
           path: ceph
 
@@ -103,7 +78,14 @@ jobs:
             -v $GITHUB_WORKSPACE/ceph:/srv/ceph \
             -e NPROC=4 \
             -e CMAKE_BUILD_TYPE=Release \
-            ${{ secrets.DOCKERHUB_USERNAME }}/buildenv-radosgw:${{ needs.set-git-refs.outputs.github-ref-name }}
+            quay.io/s3gw/build--radosgw:${{ vars.GITHUB_REF_NAME }}
+
+      - name: Test On-Disk Format
+        run: |
+          # check if on-disk format changed. If it did, it must be mentioned in
+          # the releaes notes under "breaking changes"
+          s3gw/tools/tests/on-disk-format-checker.sh || \
+            grep -A 5 -i "breaking changes" | grep -i format
 
       - name: Compress Build Results
         run: |
@@ -118,7 +100,7 @@ jobs:
       - name: Generate Artifact Identifier
         id: artifact_id
         run: |
-          ARTIFACT_ID=radosgw-${{ needs.set-git-refs.outputs.github-ref-name }}
+          ARTIFACT_ID=radosgw-${{ vars.GITHUB_REF_NAME }}
           echo "artifact_id=$ARTIFACT_ID" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
@@ -130,7 +112,6 @@ jobs:
   build-s3gw-container:
     runs-on: ubuntu-latest
     needs:
-      - set-git-refs
       - build-radosgw
 
     steps:
@@ -147,7 +128,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Quay Login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -167,17 +148,44 @@ jobs:
         with:
           push: true
           tags: |
-            quay.io/s3gw/s3gw:${{ needs.set-git-refs.outputs.github-ref-name }}
+            quay.io/s3gw/s3gw:${{ vars.GITHUB_REF_NAME }}
             quay.io/s3gw/s3gw:latest
           file: tools/build/Dockerfile.build-container
           context: ceph/build
 
+  pre-release-tests:
+    runs-on: ubuntu-latest
+    needs:
+      - build-s3gw-container
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Run Smoke Tests
+        run: |
+          source ceph/qa/rgw/store/sfs/tests/helper.sh
+
+          CONTAINER=$(docker run --rm -d \
+                        -p 7480:7480
+                        quay.io/s3gw/s3gw:${{ vars.GITHUB_REF_NAME }})
+
+          wait_for_http_200 "127.0.0.1:7480"
+
+          ceph/qa/rgw/store/sfs/tests/sfs-smoke-test.sh 127.0.0.1:7480
+
+          docker kill "$CONTAINER"
+
   # Build and push the ui container
   build-s3gw-ui-container:
     runs-on: ubuntu-latest
-    needs:
-      - set-git-refs
-
     steps:
 
       - name: Checkout
@@ -203,7 +211,7 @@ jobs:
         with:
           push: true
           tags: |
-            quay.io/s3gw/s3gw-ui:${{ needs.set-git-refs.outputs.github-ref-name }}
+            quay.io/s3gw/s3gw-ui:${{ vars.GITHUB_REF_NAME }}
             quay.io/s3gw/s3gw-ui:latest
           file: ui/Dockerfile
           context: ui
@@ -216,18 +224,18 @@ jobs:
 
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        draft: true
-        body_path: docs/release-notes/latest
-        generate_release_notes: true
-        fail_on_unmatched_files: true
-        files: |
-          LICENSE
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          body_path: docs/release-notes/latest
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            LICENSE
 
   # Release the charts
   # TODO

--- a/tools/tests/on-disk-format-checker.sh
+++ b/tools/tests/on-disk-format-checker.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+#
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ------
+#
+# This script performs tests to ensure that no unintended breaking changes are
+# introduced to the on-disk format of the s3gw.
+# It works by spinning up an old version of the s3gw, uploading a couple objects
+# to it, then reusing that volume with a new version of the s3gw, trying to read
+# those objects again and ensuring integrity with checksums along the way.
+
+[ -z "$DEBUG" ] || set -x
+
+CEPH_DIR=${CEPH_DIR:-"$PWD/ceph"}
+OLD_VERSION=${OLD_VERSION:-"latest"}
+NEW_VERSION=${NEW_VERSION:-""}
+
+S3GW_HOST=${S3GW_HOST:-"127.0.0.1:7480"}
+
+VOL=$(mktemp -q -d s3gw.XXXX --tmpdir="$PWD")
+SRC=$(mktemp -q -d src.XXXX --tmpdir="$PWD")
+DST=$(mktemp -q -d dst.XXX --tmpdir="$PWD")
+CFG="$PWD/s3cfg"
+
+CONTAINER=
+PODMAN=
+
+_podman() {
+  "$PODMAN" "$@"
+}
+
+s3() {
+  s3cmd -q -c "$CFG" "$@"
+}
+
+start_s3gw() {
+  local version="$1"
+
+  if [ -n "$version" ] ; then
+    echo "Running s3gw ${version}"
+    CONTAINER=$(_podman run \
+                  --rm -d \
+                  -v "${VOL}:/data" \
+                  -p 7480:7480 \
+                  "quay.io/s3gw/s3gw:${version}")
+  else
+    echo "Running s3gw from ${CEPH_DIR}/build/bin"
+    CONTAINER=$(_podman run \
+                  --rm -d \
+                  -v "${VOL}:/data" \
+                  -v "${CEPH_DIR}/build/bin:/radosgw/bin" \
+                  -v "${CEPH_DIR}/build/lib:/radosgw/lib" \
+                  -p 7480:7480 \
+                  quay.io/s3gw/run-radosgw \
+                    --rgw-backend-store sfs \
+                    --debug-rgw 1)
+  fi
+
+  for _ in {1..600} ; do
+    if curl -s "$S3GW_HOST" > /dev/null ; then
+      break
+    fi
+    sleep .1
+  done
+}
+
+stop_s3gw() {
+  _podman kill "$CONTAINER"
+}
+
+setup() {
+  echo "Setting up..."
+
+  if command -v podman ; then
+    PODMAN=podman
+  elif command -v docker ; then
+    PODMAN=docker
+  else
+    exit 1
+  fi
+
+  cat > "$CFG" <<EOF
+[default]
+access_key = test
+secret_key = test
+host_base = ${S3GW_HOST}/
+host_bucket = ${S3GW_HOST}/%(bucket)
+signurl_use_https = False
+use_https = False
+signature_v2 = True
+signurl_use_https = False
+EOF
+
+  for i in {1..100} ; do
+    dd if=/dev/random bs=1k count=5k of="${SRC}/obj-${i}.bin" status=none
+  done
+
+  start_s3gw "$OLD_VERSION"
+  s3 mb "s3://bucket"
+  s3 put "${SRC}"/* "s3://bucket/"
+  stop_s3gw
+
+  start_s3gw "$NEW_VERSION"
+}
+
+sha256sums() {
+  local workdir="$1"
+  pushd "$workdir" > /dev/null || exit 1
+  sha256sum ./* > checksums
+  popd > /dev/null || exit 1
+}
+
+trap cleanup EXIT
+cleanup() {
+  stop_s3gw
+  echo "Cleaning up..."
+  rm -rf "$VOL"
+  rm -rf "$SRC"
+  rm -rf "$DST"
+  rm -rf "$CFG"
+}
+
+
+test_put_more_objects() {
+  for i in {101..200} ; do
+    dd if=/dev/random bs=1k count=5k of="${SRC}/obj-${i}.bin" status=none
+  done
+
+  s3 put "${SRC}"/obj-{101..200}.bin "s3://bucket/"
+}
+
+test_get_objects() {
+  s3 get "s3://bucket/*" "${DST}/"
+}
+
+setup
+
+test_put_more_objects
+test_get_objects
+
+sha256sums "$SRC"
+sha256sums "$DST"
+
+diff "${SRC}/checksums" "${DST}/checksums"


### PR DESCRIPTION
- Add on-disk format checker able to detect the most egregious breaking on-disk format changes.
- Incorporate simple tests into release workflow
- Remove usage of Dockerhub from release workflow in favor of Quay.io
- Fix whitespace errors

The purpose of the on-disk format change test is to ensure a release with on-disk format changes has an appropriate notice in the release notes.
The purpose of the smoke test is to ensure the packaging into the container image has been successful and the runtime works as expected.

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
