### PR TITLE
ci: s3tests runner log from container

### DIFF
--- a/tools/tests/s3tests-runner.sh
+++ b/tools/tests/s3tests-runner.sh
@@ -1,6 +1,35 @@
 #!/bin/bash
+#
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# - - -
+#
+# s3tests Runner
+#
+# This script is a helper for running s3tests against the s3gw/radosgw and
+# collecting results and logs. One of the main features of this script is that
+# it manages a fresh instance of radosgw for each test, ensuring that crashing
+# or corrupting the gateway during one test does not affect the result of the
+# next test(s). In addition to that it collects logs both from the s3tests as
+# well as the logs from the radosgw instance and compiles a json file describing
+# the results of each test.
+
 
 set -e
+
+[[ -z "$DEBUG" ]] || set -x
 
 CEPH_DIR=${CEPH_DIR:-"/srv/ceph"}
 S3GW_CONTAINER=${S3GW_CONTAINER:-"quay.io/s3gw/s3gw:latest"}
@@ -12,18 +41,29 @@ S3TEST_REPO=${S3TEST_REPO:-"$(pwd)"}
 S3TEST_CONF=${S3TEST_CONF:-"${CEPH_DIR}/qa/rgw/store/sfs/tests/fixtures/s3tests.conf"}
 S3TEST_LIST=${S3TEST_LIST:-"${CEPH_DIR}/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt"}
 
-CONTAINER=
 FORCE_CONTAINER=${FORCE_CONTAINER:-"OFF"}
+FORCE_DOCKER=${FORCE_DOCKER:-"OFF"}
+
+CONTAINER=
 JOB=
 TMPFILE=
 TMPDIR=
 
 CONTAINER_CMD=
+CONTAINER_CMD_LOG_OPTS=()
 _configure() {
-  if command -v podman ; then
+  if [ ! "$FORCE_DOCKER" == "ON" ] && command -v podman ; then
     CONTAINER_CMD=podman
+    CONTAINER_CMD_LOG_OPTS=(
+      "--log-opt"
+      "path=${OUTPUT_DIR}/logs/radosgw.log"
+    )
   elif command -v docker ; then
     CONTAINER_CMD=docker
+    CONTAINER_CMD_LOG_OPTS=(
+      "--log-driver"
+      "local"
+    )
   else
     exit 2
   fi
@@ -37,7 +77,7 @@ _setup() {
 
   if [ ! -d "${CEPH_DIR}/build/bin" ] ; then
     echo "Using s3gw container"
-    CONTAINER=$("$CONTAINER_CMD" run --rm -d -p 7480:7480 quay.io/s3gw/s3gw:latest)
+    CONTAINER=$("$CONTAINER_CMD" run --rm -d -p 7480:7480 "$S3GW_CONTAINER")
   elif ! grep -q -i suse /etc/os-release || [ "${FORCE_CONTAINER}" = "ON" ] ; then
     echo "Using runtime container"
     CONTAINER=$("$CONTAINER_CMD" run \
@@ -46,7 +86,7 @@ _setup() {
       -p 7480:7480 \
       -v "${CEPH_DIR}/build/bin":"/radosgw/bin" \
       -v "${CEPH_DIR}/build/lib":"/radosgw/lib" \
-      --log-opt=path="${OUTPUT_DIR}/logs/${test}/radosgw.log" \
+      "${CONTAINER_CMD_LOG_OPTS[@]}" \
       quay.io/s3gw/run-radosgw:latest
     )
   else
@@ -103,11 +143,19 @@ _run() {
   yq -i \
     ".tests += [{\"name\": \"${name}\", \"result\": \"${result}\"}]" \
     "${TMPFILE}"
-  _teardown
+  _teardown "$test"
 }
 
 
 _teardown() {
+  local test="$1"
+
+  if [ "$CONTAINER_CMD" = "docker" ] ; then
+    docker logs "$CONTAINER" > "${OUTPUT_DIR}/logs/${test}/radosgw.log" 2>&1
+  else
+    mv "${OUTPUT_DIR}/logs/radosgw.log" "${OUTPUT_DIR}/logs/${test}/radosgw.log"
+  fi
+
   if [ -n "$CONTAINER" ] ; then
     "$CONTAINER_CMD" kill "$CONTAINER"
   else
@@ -122,6 +170,25 @@ _teardown() {
 _convert() {
   yq -o=json '.' "${TMPFILE}" > "${OUTPUT_FILE}"
   rm "${TMPFILE}"
+}
+
+
+_list_results_by_type() {
+  local type="$1"
+
+  jq \
+    ".tests[] | select( .result == \"$type\" ) | .name" \
+    "${OUTPUT_FILE}"
+}
+
+_count_results_by_type() {
+  local type="$1"
+
+  _list_results_by_type "$type" | wc -l
+}
+
+_has_failed_tests() {
+  _list_results_by_type "failure" | grep -v -q -e ".*"
 }
 
 
@@ -142,6 +209,13 @@ _main() {
   fi
 
   _convert
+
+  echo "$(_count_results_by_type "success") Successful Tests:"
+  _list_results_by_type "success"
+  echo "$(_count_results_by_type "failure") Failed Tests:"
+  _list_results_by_type "failure"
+
+  _has_failed_tests
 }
 
 

--- a/tools/tests/s3tests-runner.sh
+++ b/tools/tests/s3tests-runner.sh
@@ -46,6 +46,7 @@ _setup() {
       -p 7480:7480 \
       -v "${CEPH_DIR}/build/bin":"/radosgw/bin" \
       -v "${CEPH_DIR}/build/lib":"/radosgw/lib" \
+      --log-opt=path="${OUTPUT_DIR}/logs/${test}/radosgw.log" \
       quay.io/s3gw/run-radosgw:latest
     )
   else


### PR DESCRIPTION
Make the s3tests runner script collect logs, when running the s3gw within the runtime container. Previously, logs of the s3gw would only be collected when running in the host environment. However this isn't how the tests are run in the CI system, so in order to be able to collect logs there, the container runtime has to be instructed to write out its logs to a file, from where the logs can be collected.

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
