### PR TITLE
ci: fix missing 'uses' in releaes workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ jobs:
     steps:
 
       - name: Checkout
+        uses: actions/checkout@v3
         with:
           path: s3gw
 


### PR DESCRIPTION
Fix missing 'uses' in release workflow

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
