### PR TITLE
ci: install s3cmd in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,11 @@ jobs:
             -e CMAKE_BUILD_TYPE=Release \
             quay.io/s3gw/build-radosgw:${{ github.ref_name }}
 
+      - name: Install S3cmd
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y s3cmd
+
       - name: Test On-Disk Format
         run: |
           # check if on-disk format changed. If it did, it must be mentioned in


### PR DESCRIPTION
This is to avoid the following errors:
```bash
s3gw/tools/tests/on-disk-format-checker.sh: line 46: s3cmd: command not found
s3gw/tools/tests/on-disk-format-checker.sh: line 46: s3cmd: command not found
```
in the `Test On-Disk Format` job. 

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
