### PR TITLE
ci: fix path of helpers script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Run Smoke Tests
         run: |
-          source ceph/qa/rgw/store/sfs/tests/helper.sh
+          source ceph/qa/rgw/store/sfs/tests/helpers.sh
 
           CONTAINER=$(docker run --rm -d \
                         -p 7480:7480


### PR DESCRIPTION
This is making the ci to fail:
```bash
/home/runner/work/_temp/16e64a53-18aa-4eb0-b4ed-5f1e2a5dd4c0.sh: line 1: ceph/qa/rgw/store/sfs/tests/helper.sh: No such file or directory
Error: Process completed with exit code 1.
```

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
