### PR TITLE
ci: unify container build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   # Build the build-environment container, using it's workflow
-  build-env:
-    runs-on: ubuntu-latest
+  build-s3gw:
+    runs-on: self-hosted
     steps:
 
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -33,146 +33,19 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: quay.io/s3gw/build-radosgw:${{ github.ref_name }}
-          file: tools/build/Dockerfile.build-radosgw
-          context: tools/build
-
-  # Build the radosgw binary using the previously built container image
-  build-radosgw:
-    runs-on: ubuntu-latest
-    needs:
-      - build-env
-
-    outputs:
-      artifact_id: ${{ steps.artifact_id.outputs.artifact_id }}
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: s3gw
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: aquarist-labs/ceph
-          ref: s3gw-${{ github.ref_name }}
-          submodules: recursive
-          path: ceph
-
-      - name: Create CCache Timestamp
-        id: ccache_timestamp
-        run: |
-          echo "timestamp=$(date +%Y-%m-%d-%H:%M:%S)" >> $GITHUB_OUTPUT
-
-      - name: Cache CCache Files
-        uses: actions/cache@v3.0.4
-        with:
-          path: ceph/build.ccache
-          key: ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ccache-
-
-      - name: Build radosgw Binary
-        run: |
-          docker run --rm \
-            -v $GITHUB_WORKSPACE/ceph:/srv/ceph \
-            -e NPROC=4 \
-            -e CMAKE_BUILD_TYPE=Release \
-            quay.io/s3gw/build-radosgw:${{ github.ref_name }}
-
-      - name: Install S3cmd
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y s3cmd
-
-      - name: Test On-Disk Format
-        run: |
-          # check if on-disk format changed. If it did, it must be mentioned in
-          # the releaes notes under "breaking changes"
-          VERSION_AFTER_V=$(cut -d "v" -f2 <<< ${{ github.ref_name }})
-          VERSION_AFTER_RC=$(cut -d "-" -f1 <<< ${VERSION_AFTER_V})
-          ls -la $GITHUB_WORKSPACE/s3gw/docs/release-notes
-          EXPECTED_RN_FILE="$GITHUB_WORKSPACE/s3gw/docs/release-notes/s3gw-v${VERSION_AFTER_RC}.md"
-          if [ -f "$EXPECTED_RN_FILE" ]; then
-            s3gw/tools/tests/on-disk-format-checker.sh || \
-              grep -A 5 -i "breaking changes" ${EXPECTED_RN_FILE} | grep -i format
-          else
-            echo "Expected release-notes file: ${EXPECTED_RN_FILE} was not found"
-            exit 1
-          fi
-
-      - name: Compress Build Results
-        run: |
-          tar -czvf build-results.tar.gz \
-            ceph/build/bin/radosgw \
-            ceph/build/lib/libceph-common.so \
-            ceph/build/lib/libceph-common.so.2 \
-            ceph/build/lib/librados.so \
-            ceph/build/lib/librados.so.2 \
-            ceph/build/lib/librados.so.2.0.0
-
-      - name: Generate Artifact Identifier
-        id: artifact_id
-        run: |
-          ARTIFACT_ID=radosgw-${{ github.ref_name }}
-          echo "artifact_id=$ARTIFACT_ID" >> $GITHUB_OUTPUT
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.artifact_id.outputs.artifact_id }}
-          path: build-results.tar.gz
-
-  # Build and push the radosgw container using the radosgw-binary
-  build-s3gw-container:
-    runs-on: ubuntu-latest
-    needs:
-      - build-radosgw
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Quay Login
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Download Radogw Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.build-radosgw.outputs.artifact_id }}
-
-      - name: Unpack Artifacts
-        run: |
-          tar -xvf build-results.tar.gz
-
-      - name: Build S3GW Container
-        uses: docker/build-push-action@v3
-        with:
-          push: true
+          build-args: |
+            CMAKE_BUILD_TYPE=Release
+            NPROC=16
           tags: |
-            quay.io/s3gw/s3gw:${{ github.ref_name }}
             quay.io/s3gw/s3gw:latest
-          file: tools/build/Dockerfile.build-container
-          context: ceph/build
+            quay.io/s3gw/s3gw:${{ github.ref_name }}
+          file: Dockerfile
+          context: .
 
-  pre-release-tests:
+  pre-release-smoke-tests:
     runs-on: ubuntu-latest
     needs:
-      - build-s3gw-container
+      - build-s3gw
 
     steps:
 
@@ -181,14 +54,8 @@ jobs:
         with:
           repository: aquarist-labs/ceph
           ref: s3gw-${{ github.ref_name }}
-          submodules: recursive
+          submodules: false
           path: ceph
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
 
       - name: Install S3cmd
         run: |
@@ -208,6 +75,41 @@ jobs:
           ceph/qa/rgw/store/sfs/tests/sfs-smoke-test.sh 127.0.0.1:7480
 
           docker kill "$CONTAINER"
+
+  pre-release-on-disk-format-test:
+    runs-on: ubuntu-latest
+    needs:
+      - build-s3gw
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install S3cmd
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y s3cmd
+
+      - name: Run On-Disk Format Test
+        run: |
+          NEW_VERSION=${{ github.ref_name }}
+          OLD_VERSION=$(git describe --abbrev=0 --tags ${{ github.ref_name }}^)
+
+          VERSION_AFTER_V=$(cut -d "v" -f2 <<< ${{ github.ref_name }})
+          VERSION_AFTER_RC=$(cut -d "-" -f1 <<< ${VERSION_AFTER_V})
+          ls -la $GITHUB_WORKSPACE/s3gw/docs/release-notes
+          EXPECTED_RN_FILE="$GITHUB_WORKSPACE/s3gw/docs/release-notes/s3gw-v${VERSION_AFTER_RC}.md"
+
+          if [ -f "$EXPECTED_RN_FILE" ]; then
+            s3gw/tools/tests/on-disk-format-checker.sh || \
+              grep -A 5 -i "breaking changes" ${EXPECTED_RN_FILE} | grep -i format
+          else
+            echo "Expected release-notes file: ${EXPECTED_RN_FILE} was not found"
+            exit 1
+          fi
 
   # Build and push the ui container
   build-s3gw-ui-container:
@@ -245,8 +147,8 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     needs:
-      - build-s3gw-container
-      - build-s3gw-ui-container
+      - pre-release-smoke-test
+      - pre-release-on-disk-format-test
 
     steps:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,24 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build Buildenv Container
+      - name: Build Unittests
+        uses: docker/build-push-action@v4
+        with:
+          load: true
+          build-args: |
+            CMAKE_BUILD_TYPE=Release
+            NPROC=16
+          tags: |
+            s3gw-unittests
+          target: s3gw-unittests
+          file: Dockerfile
+          context: .
+
+      - name: Run Unittests
+        run: |
+          docker run --rm s3gw-unittests
+
+      - name: Build s3gw Container Image
         uses: docker/build-push-action@v4
         with:
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,173 @@
+FROM opensuse/leap:15.4 as s3gw-base
+
+RUN zypper ar \
+  https://download.opensuse.org/repositories/filesystems:/ceph:/s3gw/15.4/ \
+  s3gw-deps \
+ && zypper --gpg-auto-import-keys ref
+
+FROM s3gw-base as buildenv
+
+ARG CMAKE_BUILD_TYPE=Debug
+
+ENV SRC_CEPH_DIR="${SRC_CEPH_DIR:-"./ceph"}"
+ENV ENABLE_GIT_VERSION=OFF
+
+# Add OBS repository for additional dependencies necessary on Leap 15.4
+RUN zypper -n install --no-recommends \
+      'cmake>3.5' \
+      'fmt-devel>=6.2.1' \
+      'gperftools-devel>=2.4' \
+      'libblkid-devel>=2.17' \
+      'liblz4-devel>=1.7' \
+      'libthrift-devel>=0.13.0' \
+      'pkgconfig(libudev)' \
+      'pkgconfig(systemd)' \
+      'pkgconfig(udev)' \
+      babeltrace-devel \
+      binutils \
+      ccache \
+      cmake \
+      cpp11 \
+      cryptsetup-devel \
+      cunit-devel \
+      fdupes \
+      fuse-devel \
+      gcc-c++ \
+      gcc11 \
+      gcc11-c++ \
+      git \
+      gperf \
+      jq \
+      keyutils-devel \
+      libaio-devel \
+      libasan6 \
+      libboost_atomic1_80_0-devel \
+      libboost_context1_80_0-devel \
+      libboost_coroutine1_80_0-devel \
+      libboost_filesystem1_80_0-devel \
+      libboost_iostreams1_80_0-devel \
+      libboost_program_options1_80_0-devel \
+      libboost_python-py3-1_80_0-devel \
+      libboost_random1_80_0-devel \
+      libboost_regex1_80_0-devel \
+      libboost_system1_80_0-devel \
+      libboost_thread1_80_0-devel \
+      libbz2-devel \
+      libcap-devel \
+      libcap-ng-devel \
+      libcurl-devel \
+      libexpat-devel \
+      libicu-devel \
+      libnl3-devel \
+      liboath-devel \
+      libopenssl-devel \
+      libpmem-devel \
+      libpmemobj-devel \
+      librabbitmq-devel \
+      librdkafka-devel \
+      libsqliteorm \
+      libstdc++6-devel-gcc11 \
+      libtool \
+      libtsan0 \
+      libxml2-devel \
+      lttng-ust-devel \
+      lua-devel \
+      lua53-luarocks \
+      make \
+      memory-constraints \
+      mozilla-nss-devel \
+      nasm \
+      ncurses-devel \
+      net-tools \
+      ninja \
+      ninja \
+      openldap2-devel \
+      patch \
+      perl \
+      pkgconfig \
+      procps \
+      python3 \
+      python3-Cython \
+      python3-PrettyTable \
+      python3-PyYAML \
+      python3-Sphinx \
+      python3-devel \
+      python3-setuptools \
+      rdma-core-devel \
+      re2-devel \
+      rpm-build \
+      snappy-devel \
+      sqlite-devel \
+      systemd-rpm-macros \
+      systemd-rpm-macros \
+      valgrind-devel \
+      xfsprogs-devel \
+      xmlstarlet \
+ && zypper clean --all
+
+COPY $SRC_CEPH_DIR /srv/ceph
+
+WORKDIR /srv/ceph
+
+RUN /srv/ceph/qa/rgw/store/sfs/build-radosgw.sh
+
+FROM s3gw-base as s3gw
+
+ARG S3GW_VERSION
+ARG ID=s3gw
+
+ENV ID=${ID}
+
+LABEL Name=s3gw
+LABEL Version=${S3GW_VERSION}
+
+RUN zypper -n install \
+  libblkid1 \
+  libexpat1 \
+  libtcmalloc4 \
+  libfmt9 \
+  liboath0 \
+  libicu-suse65_1 \
+  libthrift-0_16_0 \
+  libboost_atomic1_80_0 \
+  libboost_chrono1_80_0 \
+  libboost_context1_80_0 \
+  libboost_coroutine1_80_0 \
+  libboost_date_time1_80_0 \
+  libboost_filesystem1_80_0 \
+  libboost_iostreams1_80_0 \
+  libboost_program_options1_80_0 \
+  libboost_random1_80_0 \
+  libboost_regex1_80_0 \
+  libboost_serialization1_80_0 \
+  libboost_system1_80_0 \
+  libboost_thread1_80_0 \
+ && zypper clean --all \
+ && mkdir -p \
+  /radosgw/bin \
+  /radosgw/lib \
+  /data
+
+ENV PATH=/radosgw/bin:$PATH
+ENV LD_LIBRARY_PATH=/radosgw/lib:$LD_LIBRARY_PATH
+VOLUME ["/data"]
+
+COPY --from=buildenv /srv/ceph/build/bin/radosgw /radosgw/bin
+COPY --from=buildenv [ \
+  "/srv/ceph/build/lib/librados.so", \
+  "/srv/ceph/build/lib/librados.so.2", \
+  "/srv/ceph/build/lib/librados.so.2.0.0", \
+  "/srv/ceph/build/lib/libceph-common.so", \
+  "/srv/ceph/build/lib/libceph-common.so.2", \
+  "/radosgw/lib/" ]
+
+EXPOSE 7480
+EXPOSE 7481
+
+ENTRYPOINT [ "radosgw", "-d", \
+  "--no-mon-config", \
+  "--id", "${ID}", \
+  "--rgw-data", "/data/", \
+  "--run-dir", "/run/", \
+  "--rgw-sfs-data-path", "/data" ]
+CMD [ "--rgw-backend-store", "sfs", "--debug-rgw", "1" ]


### PR DESCRIPTION
Unify the container build by creating a multi-stage contaienr which takes a copy of the ceph subrepo and builds the radosgw binary with the sfs backend inside it. The next stage then creates a runtime container capable of executing the resulting artefacts.
The total result of this is that building the s3gw container is no more compliacted that a `docker build -t s3gw .`

Requires-pr: aquarist-labs/ceph#130

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
