### PR TITLE
ci: explicitly set up docker context

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,14 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      - name: Set up Docker Context
+        run: |
+          docker context create builder
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          endpoint: builder
 
       - name: Quay Login
         uses: docker/login-action@v2


### PR DESCRIPTION
When using self-hosted runners, the docker context needs to be explicitly set up for buildx. Buildx is needed on the other hand for the build-push action

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
