### PR TITLE
The Traefik ingress is misconfigured, Access-Control-Expose-Headers must be set to '*'

### DIFF
--- a/tools/env/ingress-traefik/s3gw-ingress.yaml
+++ b/tools/env/ingress-traefik/s3gw-ingress.yaml
@@ -17,7 +17,7 @@ spec:
     accessControlAllowHeaders:
       - "*"
     accessControlExposeHeaders:
-      - "ETag"
+      - "*"
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
The `accessControlExposeHeaders` property is set to `*` now to expose all headers by default. To fix the mentioned issue adding the `X-Amz-Object-Lock-Mode` and `X-Amz-Object-Lock-Retain-Until-Date` would be sufficient, but the problem might appear again in the future, but with a different header that is processed by the AWS SDK but is not exposed by the ingress.

References:
- https://github.com/aquarist-labs/s3gw-charts/pull/89
- https://github.com/aquarist-labs/s3gw/issues/410

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
