### PR TITLE
ci: fix s3test-runner for host environment

### DIFF
--- a/tools/tests/s3tests-runner.sh
+++ b/tools/tests/s3tests-runner.sh
@@ -152,20 +152,19 @@ _teardown() {
 
   if [ "$CONTAINER_CMD" = "docker" ] ; then
     docker logs "$CONTAINER" > "${OUTPUT_DIR}/logs/${test}/radosgw.log" 2>&1
+  elif [ -n "$CONTAINER" ] ; then
+    mv "${OUTPUT_DIR}/logs/radosgw.log" "${OUTPUT_DIR}/logs/${test}/radosgw.log"
   fi
 
   if [ -n "$CONTAINER" ] ; then
     set +e
     "$CONTAINER_CMD" kill "$CONTAINER"
     "$CONTAINER_CMD" rm "$CONTAINER"
+    CONTAINER=
     set -e
   else
     kill "$JOB"
     rm -rf "${TMPDIR}"
-  fi
-
-  if [ ! "$CONTAINER_CMD" = "docker" ] ; then
-    mv "${OUTPUT_DIR}/logs/radosgw.log" "${OUTPUT_DIR}/logs/${test}/radosgw.log"
   fi
 
   popd > /dev/null || exit 1


### PR DESCRIPTION
Fix the s3test runner script when running with the host-environment. This fixes a logic bug that assumed not using docker would always mean using podman, which isn't the case when running without containers entirely.

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
