### PR TITLE
Add minikube instant demo script

### DIFF
--- a/tools/minikube/instant-demo.sh
+++ b/tools/minikube/instant-demo.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+set -u
+
+: "${USE_SSL:=false}"
+: "${S3GW_CHARTS:="https://aquarist-labs.github.io/s3gw-charts/"}"
+
+if ! [[ $S3GW_CHARTS =~ https?:// || -r "${S3GW_CHARTS}/Chart.yaml" ]]; then
+	echo "S3GW_CHARTS set to something weird ($S3GW_CHARTS)"
+	echo "Please set to the s3gw charts dir (e.g s3gw-charts/charts/s3gw) or a remote location"
+	exit 1
+fi
+
+set -x
+
+minikube start --driver=kvm2 --extra-disks=0
+
+helm repo add jetstack https://charts.jetstack.io
+helm repo add traefik https://traefik.github.io/charts
+
+helm repo update
+
+backend_proto="http"
+
+if [[ $USE_SSL == "true" ]]; then
+	backend_proto="https"
+	helm install cert-manager \
+		--namespace cert-manager jetstack/cert-manager \
+		--create-namespace \
+		--set installCRDs=true \
+		--set extraArgs[0]=--enable-certificate-owner-ref=true
+fi
+helm install traefik-ingress traefik/traefik
+
+traefik_cluster_ip="$(kubectl \
+	get service \
+	traefik-ingress -ojsonpath='{.spec.clusterIP}')"
+helm_values_file="$(mktemp)"
+trap "rm $helm_values_file" EXIT
+
+cat >"$helm_values_file" <<EOF
+ingress:
+  enabled: true
+useCertManager: ${USE_SSL}
+certManagerNamespace: cert-manager
+tlsIssuer: "s3gw-issuer"
+email: "mail@example.com"
+ui:
+  enabled: true
+  serviceName: "s3gw-ui"
+  publicDomain: "fe.${traefik_cluster_ip}.omg.howdoi.website"
+  backendProtocol: "${backend_proto}"
+serviceName: "s3gw"
+useExistingSecret: false
+defaultUserCredentialsSecret: "s3gw-creds"
+accessKey: "test"
+secretKey: "test"
+publicDomain: "be.${traefik_cluster_ip}.omg.howdoi.website"
+privateDomain: "svc.cluster.local"
+storageSize: 10Gi
+storageClass:
+  name: "standard"
+  create: false
+logLevel: "1"
+EOF
+
+helm install s3gw "${S3GW_CHARTS}" \
+	--namespace s3gw \
+	--create-namespace \
+	-f "$helm_values_file"
+
+set +x
+
+echo "Please wait a sec until all pods are up"
+
+minikube tunnel
+
+echo "You may want to run minikube delete"


### PR DESCRIPTION
Depends on https://github.com/aquarist-labs/s3gw-charts/pull/94

Run ./instant-demo.sh. Get minikube with S3GW, S3GW-UI and Traefik
Ingress controller in a couple of minutes.

Defaults to a non-SSL setup. Set USE_SSL=true to enable
a cert manager based SSL setup.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
