### PR TITLE
fix Dockerfile not capturing all the sfs unittests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN /srv/ceph/qa/rgw/store/sfs/build-radosgw.sh
 
 FROM s3gw-base as s3gw-unittests
 
-COPY --from=buildenv /srv/ceph/build/bin/unittest_rgw_sfs* /radosgw/bin/
+COPY --from=buildenv /srv/ceph/build/bin/unittest_rgw_* /radosgw/bin/
 COPY --from=buildenv [ \
   "/srv/ceph/build/lib/librados.so", \
   "/srv/ceph/build/lib/librados.so.2", \
@@ -154,7 +154,7 @@ COPY --from=buildenv [ \
   "/radosgw/lib/" ]
 
 ENTRYPOINT [ "bin/bash", "-x", "-c" ]
-CMD [ "find /radosgw/bin -name \"unittest_rgw_sfs*\" -print0 | xargs -0 -n1 bash -ec"]
+CMD [ "find /radosgw/bin -name \"unittest_rgw_*\" -print0 | xargs -0 -n1 bash -ec"]
 
 FROM s3gw-base as s3gw
 


### PR DESCRIPTION
Dockerfile was capturing unittest_rgw_sfs* pattern but not unittest_rgw_s3gw*

Fixes: https://github.com/aquarist-labs/s3gw/issues/447
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
