### PR TITLE
ci: fix GNU parallel in s3tests runner

### DIFF
--- a/tools/tests/s3tests-runner.sh
+++ b/tools/tests/s3tests-runner.sh
@@ -79,6 +79,10 @@ _configure() {
     exit 2
   fi
 
+  # if running in a github worker, the home directory can't be accessed, so the
+  # configuration must be stored elsewhere.
+  export PARALLEL_HOME=${GITHUB_WORKSPACE:-"${PARALLEL_HOME:-"$HOME"}"}
+
   if [ "$S3TEST_LIFECYCLE" == "ON" ] ; then
     LIFE_CYCLE_INTERVAL_PARAM="--rgw-lc-debug-interval ${S3TEST_LIFECYCLE_INTERVAL}"
     CONTAINER_EXTRA_PARAMS="${DEFAULT_S3GW_CONTAINER_CMD} ${LIFE_CYCLE_INTERVAL_PARAM}"


### PR DESCRIPTION
The s3tests runner script needs GNU parallel to run s3tests in parallel. With the default configuration, GNU parallel tries to store environmental configurations in $HOME, to which it has no write access in a GitHub worker.
Set $PARALLEL_HOME environment variable automatically to $GITHUB_WORKSPACE to fix this issue.

Fixes: #467

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
