### PR TITLE
ci/s3tests-runner.sh : export CONTAINER_EXTRA_PARAMS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: s3gw
-          submodules: true
+          submodules: false
+
+      - name: Checkout ceph
+        uses: actions/checkout@v3
+        with:
+          repository: aquarist-labs/ceph
+          path: s3gw/ceph
 
       - name: Checkout s3tests
         uses: actions/checkout@v3

--- a/tools/tests/s3tests-runner.sh
+++ b/tools/tests/s3tests-runner.sh
@@ -279,6 +279,8 @@ _main() {
     export TMPFILE
     export OUTPUT_DIR
     export PARALLEL_HOME
+    export CONTAINER_EXTRA_PARAMS
+    export LIFE_CYCLE_INTERVAL_PARAM
 
     mkdir -p "$PARALLEL_HOME"
     parallel --record-env


### PR DESCRIPTION
Lifecycle tests are not working because the `CONTAINER_EXTRA_PARAMS` variable is not exported when running `gnu parallel`. 

We need that variable because it passes `--rgw-lc-debug-interval` when life cycle tests are enabled (they are enabled by default)

It also adds the `LIFE_CYCLE_INTERNAL_PARAM` variable as that one is needed when not running s3tests with the container option.

Fixes: https://github.com/aquarist-labs/s3gw/issues/474

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
