### PR TITLE
ci: fix nightly workflow's docker and test

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,11 +5,15 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Every night midnight
 
+  # This workflow needs to pass if there is a PR changing it.
+  pull_request:
+    path:
+      - ".github/workflows/nightly.yaml"
+
   workflow_dispatch:   # Or manually - for testing
 
 jobs:
-  # Build the build-environment container, using it's workflow
-  build-env:
+  build-and-test:
     runs-on: self-hosted
     steps:
 
@@ -18,14 +22,26 @@ jobs:
         with:
           submodules: true
 
+      - name: Checkout Ceph HEAD
+        working-directory: ceph
+        run: |
+          git fetch
+          git checkout s3gw
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      - name: Set up Docker Context
+        run: |
+          docker context create builder
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          endpoint: builder
 
-      - name: Dockerhub Login
-        uses: docker/login-action@v1
+      - name: Quay Login
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -51,3 +67,33 @@ jobs:
             quay.io/s3gw/s3gw:nightly-latest
           file: Dockerfile
           context: .
+
+      - name: Run S3tests
+        run: |
+          set +e  # don't exit on error
+          set -x
+
+          # needed for GNU parallel because the version in GH runners is bugged
+          mkdir -p ${HOME}/.parallel
+
+          export DEBUG=1
+          export S3TEST_PARALLEL=ON
+          export CEPH_DIR="${GITHUB_WORKSPACE}/ceph"
+          export OUTPUT_DIR="${GITHUB_WORKSPACE}/s3test-results"
+          export S3GW_CONTAINER="quay.io/s3gw/s3gw:nightly-latest"
+          export FORCE_CONTAINER=ON
+          export FORCE_DOCKER=ON
+          export \
+            FIXTURES="${GITHUB_WORKSPACE}/ceph/qa/rgw/store/sfs/tests/fixtures"
+
+          export S3TEST_REPO="${GITHUB_WORKSPACE}/s3tests"
+          export S3TEST_CONF="${FIXTURES}/s3tests.conf"
+          export S3TEST_LIST="${FIXTURES}/s3-tests.txt"
+
+          sed -r -i 's/^# //' "${S3TEST_LIST}"
+
+          pushd s3tests
+          ${GITHUB_WORKSPACE}/s3gw/tools/tests/s3tests-runner.sh
+
+          # We expect some tests to fail, we just want to see _which_ tests fail
+          exit 0


### PR DESCRIPTION
- Fix nightly workflow's docker setup

- Fetch and use the latest HEAD of the ceph source to build nightlies from

- Run all s3tests on the nightly container and generate a list of passing/failing tests

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
