### PR TITLE
ci: fix ondisk format checker

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,6 +133,8 @@ jobs:
           EXPECTED_RN_FILE="$GITHUB_WORKSPACE/docs/release-notes/s3gw-v${VERSION_AFTER_RC}.md"
 
           if [ -f "$EXPECTED_RN_FILE" ]; then
+            export NEW_VERSION
+            export OLD_VERSION
             tools/tests/on-disk-format-checker.sh || \
               sed -n '/## Breaking Changes/,/## Known Issues/p' \
                   "${EXPECTED_RN_FILE}" | grep -i "format"


### PR DESCRIPTION
Export variables to make the ondisk format checker script pick them up.
