### PR TITLE
Adds triage label to new & reopened issues

### DIFF
--- a/.github/workflows/triage-label.yaml
+++ b/.github/workflows/triage-label.yaml
@@ -1,0 +1,21 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["triage/waiting"]
+            })


### PR DESCRIPTION
# Describe your changes
When a new issue is added or reopened, it gets this label automatically assigned. This is to help the team find new issues & review them.

## Issue ticket number and link
n/a

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
