### PR TITLE
tools: Add s3tests runner and analysis tools

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+extend-ignore = E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,13 @@ repos:
     hooks:
     - id: black
       language_version: python3.10
-      files: (?x)^tools/release/releasetool\.py$
+      files: (?x)^tools/(release|s3tests)/.+\.py$
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
-        files: (?x)^tools/release/releasetool\.py$
+        files: (?x)^tools/(release|s3tests)/.+\.py$
 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
@@ -69,7 +69,7 @@ repos:
           - flake8-bugbear
           - flake8-comprehensions
           - flake8-simplify
-        files: (?x)^tools/release/releasetool\.py$
+        files: (?x)^tools/(release|s3tests)/.+\.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.1.1'
@@ -78,11 +78,12 @@ repos:
         additional_dependencies:
           - types-requests
           - types-python-dateutil
-    files: (?x)^tools/release/releasetool\.py$
+          - types-PyYAML
+        files: (?x)^tools/(release|s3tests)/.+\.py$
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.10.0
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
-        files: (?x)^tools/release/releasetool\.py$
+        files: (?x)^tools/(release|s3tests)/.+\.py$

--- a/tools/s3tests/Dockerfile
+++ b/tools/s3tests/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.10-alpine
+WORKDIR /s3tr
+
+# Install s3-tests master branch
+#RUN apt-get update && apt-get -y install --no-install-recommends wget unzip \
+RUN apk add -u wget unzip \
+    && wget --quiet https://github.com/ceph/s3-tests/archive/refs/heads/master.zip \
+    && ( echo "95530ce236fcea0a8b6776f1dae786dd4f1d22fe35da23b48353c70580c928d7 master.zip" | sha256sum -c ) \
+    && unzip master.zip \
+    && rm master.zip
+
+# Used by s3tr to find s3-tests
+ENV S3TESTS=/s3tr/s3-tests-master
+ENV PYTEST_INI=/s3tr/s3-tests-master/pytest.ini
+ENV DATASETTE_METADATA=/s3tr/metadata.yml
+ENV PATH="${PATH}:/usr/local/bin"
+
+COPY requirements.txt /s3tr/
+RUN pip install --no-cache-dir -r "/s3tr/s3-tests-master/requirements.txt" \
+    && pip install --no-cache-dir -r "/s3tr/requirements.txt" \
+    && find /usr/local/lib -name '__pycache__' | xargs rm -r \
+    && rm -rf /root/.cache/pip
+
+COPY ["analyze.py", "runner.py", "s3tr.py", "to_sqlite.py", "metadata.yml", "/s3tr/"]
+
+EXPOSE 8080
+ENTRYPOINT [ "python3", "./s3tr.py" ]

--- a/tools/s3tests/analyze.py
+++ b/tools/s3tests/analyze.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+"""
+Simple analysis tasks for s3tr JSON results
+"""
+
+import json
+import logging
+import pathlib
+import sys
+
+import click
+import requests
+import rich
+from rich.console import Console
+from rich.table import Table
+
+LOG = logging.getLogger("s3tr")
+
+
+@click.group()
+def analyze():
+    """Analyze s3tr JSON results"""
+
+
+def get_upstream_list():
+    resp = requests.get(
+        "https://raw.githubusercontent.com/aquarist-labs/ceph"
+        "/s3gw/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt"
+    )
+    resp.raise_for_status()
+    return resp.text
+
+
+def get_known_good(file=None):
+    if file:
+        with open(file) as fp:
+            data = fp.read().split("\n")
+    else:
+        data = get_upstream_list().split("\n")
+
+    return frozenset(test for test in data if test and not test.startswith("#"))
+
+
+@analyze.command()
+@click.option(
+    "--known-good-file",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+)
+@click.argument(
+    "file",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+    nargs=1,
+)
+def new_failures(known_good_file, file):
+    """
+    Compare results to known good from latest main branch
+    """
+    console = Console()
+
+    known_good = get_known_good(known_good_file)
+    with open(file) as fp:
+        results = json.load(fp)
+
+    results = {result["test"].split("::")[1]: result for result in results}
+
+    success = frozenset(
+        (name for name, result in results.items() if result["test_return"] == "success")
+    )
+
+    known_good_that_fail_now = known_good - success
+
+    table = Table(box=rich.box.SIMPLE, caption="Known good tests that fail now")
+    table.add_column("Test Name")
+    table.add_column("Test Result")
+    table.add_column("Container Exit")
+    for test in known_good_that_fail_now:
+        table.add_row(
+            test, results[test]["test_return"], results[test]["container_return"]
+        )
+    console.print(table)
+    if len(known_good_that_fail_now) > 0:
+        sys.exit(23)
+
+
+@analyze.command()
+@click.option(
+    "--known-good-file",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+)
+@click.argument(
+    "file",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+    nargs=1,
+)
+def new_successes(known_good_file, file):
+    """
+    What to add to s3-tests.txt?
+    """
+    known_good = get_known_good(known_good_file)
+    with open(file) as fp:
+        results = json.load(fp)
+    results = {result["test"].split("::")[1]: result for result in results}
+    success = frozenset(
+        (name for name, result in results.items() if result["test_return"] == "success")
+    )
+
+    succeeding_not_in_known_good = success - known_good
+    print("\n".join(succeeding_not_in_known_good))
+
+
+def get_result(file, test_name):
+    with open(file) as fp:
+        results = json.load(fp)
+    return next(result for result in results if test_name in result["test"])
+
+
+def print_result(file, test_name, key):
+    result = get_result(file, test_name)
+    LOG.info(
+        f"Test {result['test']} result "
+        f"{result['test_return']} / {result['test_data']['outcome']}"
+    )
+    print(get_result(file, test_name)[key])
+
+
+@analyze.command()
+@click.argument(
+    "file",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+    nargs=1,
+)
+@click.argument(
+    "test-name",
+    type=str,
+    required=True,
+    nargs=1,
+)
+def logs(file, test_name):
+    """
+    What to add to s3-tests.txt?
+    """
+    print_result(file, test_name, "container_logs")
+
+
+@analyze.command()
+@click.argument(
+    "file",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+    nargs=1,
+)
+@click.argument(
+    "test-name",
+    type=str,
+    required=True,
+    nargs=1,
+)
+def test_out(file, test_name):
+    """
+    What to add to s3-tests.txt?
+    """
+    print_result(file, test_name, "test_output")

--- a/tools/s3tests/metadata.yml
+++ b/tools/s3tests/metadata.yml
@@ -1,0 +1,59 @@
+databases:
+  title: "S3GW S3 Test Results"
+  results:
+    tables:
+      results:
+        columns:
+          out: S3 Test output
+          log_container: s3gw radosgw container log
+        label_column: test
+        facets:
+          - result
+      results_keywords:
+        facets:
+          - keyword
+      results_with_keywords:
+        label_column: test
+        facets:
+          - array: keywords
+          - result
+    queries:
+      not-supported-errors:
+        title: Container Log - Not Supported Errors
+        label_column: test
+        sql: |-
+          select test, result, out, log_container
+          from results where rowid in
+             (select rowid from results_fts
+              where results_fts
+              match 'err_no*95 OR ENOTSUP OR ret*95 OR status*95')
+          order by test
+      todo-log-messages:
+        title: Container Log - TODOs
+        sql: |-
+          select test, result, out, log_container
+          from results where rowid in
+             (select rowid from results_fts
+              where results_fts
+              match 'log_container:TODO')
+          order by test
+      summary:
+        title: Summary
+        sql: |-
+          select result, count(*) as count from results group by result
+          union
+          select 'total', count(*) from results
+          union
+          select 'total failed', count(*) from results where result != 'success'
+      fail:
+        title: Failures by group
+        sql: |-
+          select
+            keyword,
+            count(case when result == 'success' then 1 end) as success,
+            count(case when result != 'success' then 1 end) as fail
+          from
+            results
+            inner join results_keywords on results.test = results_keywords.test
+          group by
+            keyword

--- a/tools/s3tests/requirements.txt
+++ b/tools/s3tests/requirements.txt
@@ -1,0 +1,10 @@
+pytest-json-report
+click
+sqlite-utils
+radosgw-admin
+docker
+requests
+rich
+datasette
+uvicorn
+pyyaml

--- a/tools/s3tests/runner.py
+++ b/tools/s3tests/runner.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""
+A s3-tests runner tailored to s3gw containers with parallel execution,
+result and log gathering
+"""
+
+import io
+import json
+import logging
+import multiprocessing
+import os
+import pathlib
+import random
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from contextlib import suppress
+
+import click
+import docker
+import radosgw
+import requests
+
+LOG = logging.getLogger("s3tr")
+
+# How long an individual pytest may run in seconds
+PYTEST_TIMEOUT_SEC = 100
+
+# From vstart.sh::do_rgw_create_users
+S3TESTS_USERS = {
+    "s3 main": {
+        "uid": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "access_key": "ABCDEFGHIJKLMNOPQRST",
+        "secret_key": "abcdefghijklmnopqrstuvwxyzabcdefghijklmn",
+        "display_name": "youruseridhere",
+        "email": "s3@example.com",
+        "user_caps": "user-policy=*",
+    },
+    "s3 alt": {
+        "uid": "56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234",
+        "access_key": "NOPQRSTUVWXYZABCDEFG",
+        "secret_key": "nopqrstuvwxyzabcdefghijklmnabcdefghijklm",
+        "display_name": "john.doe",
+        "email": "john.doe@example.com",
+    },
+    "s3 tenant": {
+        "uid": "9876543210abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "access_key": "HIJKLMNOPQRSTUVWXYZA",
+        "secret_key": "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzab",
+        "display_name": "testx$tenanteduser",
+        "email": "tenanteduser@example.com",
+    },
+}
+
+
+def make_radosgw_command(id, port):
+    return [
+        "stdbuf",
+        "-oL",
+        "radosgw",
+        "-d",
+        "--no-mon-config",
+        "--id",
+        id,
+        "--rgw-data",
+        "/data",
+        "--run-dir",
+        "/run/",
+        "--rgw-sfs-data-path",
+        "/data",
+        "--rgw-s3gw-telemetry-update-interval",
+        "0",
+        "--rgw-backend-store",
+        "sfs",
+        "--rgw-enable-ops-log",
+        "0",
+        "--rgw-log-object-name",
+        "0",
+        "--rgw-crypt-require-ssl",
+        "0",
+        "--rgw_crypt_s3_kms_backend",
+        "testing",
+        "--rgw_crypt_s3_kms_encryption_keys",
+        "testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= "
+        "testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=",
+        "--rgw_crypt_default_encryption_key",
+        "4YSmvJtBv0aZ7geVgAsdpRnLBEwWSWlMIGnRS8a9TSA=",
+        "--rgw-lc-debug-interval",
+        "10",
+        "--log-flush-on-exit",
+        "1",
+        "--log-to-stderr",
+        "1",
+        "--err-to-stderr",
+        "1",
+        "--log-max-recent",
+        "1",
+        "--debug-rgw",
+        "10",
+        "--rgw-frontends",
+        f'"beast port={port}"',
+        "2>&1 1> /log",
+    ]
+
+
+class S3GW:
+    """
+    An S3GW container.
+
+    Lifecycle: start(), stop(), remove()
+    Resources: logs(), logfile(), network_address()
+    Status: http_up()
+    Admin OPs: create_user()
+    """
+
+    def __init__(self, cri, image, container_run_args, name, port):
+        self.cri = cri
+        self.image = image
+        self.container_run_args = container_run_args
+        self.name = name
+        self.port = port
+        self.container = None
+
+    def start(self):
+        command = make_radosgw_command(self.name, self.port)
+        kwargs = self.container_run_args | {
+            "image": self.image,
+            "name": f"s3gw_{self.name}",
+            "detach": True,
+            "stop_signal": "SIGTERM",
+            "labels": ["s3gw_s3tests"],
+            "entrypoint": "/bin/sh",
+            "command": ["-c", " ".join(command)],
+        }
+        container = self.cri.containers.run(**kwargs)
+        LOG.debug(
+            "running s3gw container %s with %r status %s",
+            container.name,
+            kwargs,
+            container.status,
+        )
+        assert container.status != "exited"
+        self.container = container
+        self.container.reload()
+
+    def network_address(self):
+        for retry in range(5):
+            addr = self.container.attrs["NetworkSettings"]["IPAddress"]
+            if addr:
+                return addr
+            time.sleep(2 * (retry + 1))
+            self.container.reload()
+        raise RuntimeError(
+            f"Container has no network address after {retry} tries. "
+            "Startup failed? "
+            "Check container logs."
+        )
+
+    def http_up(self):
+        try:
+            resp = requests.head(f"http://{self.network_address()}:{self.port}")
+            return resp.ok
+        except requests.exceptions.ConnectionError:
+            return False
+
+    def create_user(self, **kwargs):
+        rgwadmin = radosgw.connection.RadosGWAdminConnection(
+            host=self.network_address(),
+            port=self.port,
+            access_key="test",
+            secret_key="test",
+            is_secure=False,
+        )
+        return rgwadmin.create_user(**kwargs)
+
+    def logs(self):
+        # container.logs() not 100% reliably get the logs right away.
+        # sometimes only after a minute or so..
+        for retry in range(20):
+            logs = self.container.logs()
+            if logs:
+                return logs.decode("utf-8")
+            LOG.info(f"no logs for {self.container} after {retry} tries")
+            time.sleep(2 * (retry + 1))
+        LOG.warning(
+            f"no logs for {self.container} after 20 retries. returning not available"
+        )
+        return "not available"
+
+    def logfile(self):
+        # reliable but slow alternative to logs(). needs the container
+        # to write to /logs
+        with tempfile.NamedTemporaryFile() as fp:
+            try:
+                bits, stat = self.container.get_archive("/log")
+                for chunk in bits:
+                    fp.write(chunk)
+            except docker.errors.NotFound:
+                LOG.error("logfile not found")
+                return "not found"
+            fp.seek(0)
+            log = io.BytesIO()
+            with tarfile.open(fp.name) as tf:
+                for entry in tf:
+                    fp = tf.extractfile(entry)
+                    if not fp:
+                        continue
+                    log.write(fp.read())
+                    break
+            log.seek(0)
+            return log.getvalue().decode("utf-8")
+
+    def stop(self):
+        LOG.debug(
+            "s3gw stopping container %s. was in state %s",
+            self.container,
+            self.container.status,
+        )
+
+        if self.container.status not in ("running", "created"):
+            return "crash"
+        else:
+            with suppress(docker.errors.APIError):
+                self.container.stop(timeout=10)
+            return "success"
+
+    def remove(self):
+        with suppress(docker.errors.APIError):
+            self.container.remove()
+
+
+def get_tests(s3_tests_path, search_string):
+    result = []
+    out = subprocess.check_output(
+        [
+            "pytest",
+            "--collect-only",
+            "-q",
+            "--disable-warnings",
+            "--no-header",
+            "--no-summary",
+            search_string,
+        ],
+        cwd=s3_tests_path,
+    )
+    for line in out.decode("utf-8").split("\n"):
+        if line.startswith("s3tests"):
+            result.append(line.strip())
+    return result
+
+
+def mk_config(host, port, users):
+    return f"""
+[DEFAULT]
+host = {host}
+port = {port}
+is_secure = False
+ssl_verify = False
+
+[fixtures]
+bucket prefix = sfstest-{{random}}-
+
+[s3 main]
+display_name = {users['s3 main']['display_name']}
+user_id = {users['s3 main']['uid']}
+email = {users['s3 main']['email']}
+access_key = {users['s3 main']['access_key']}
+secret_key = {users['s3 main']['secret_key']}
+api_name = default
+lc_debug_interval = 10
+
+[s3 alt]
+display_name = {users['s3 alt']['display_name']}
+user_id = {users['s3 alt']['uid']}
+email = {users['s3 alt']['email']}
+access_key = {users['s3 alt']['access_key']}
+secret_key = {users['s3 alt']['secret_key']}
+
+[s3 tenant]
+display_name = {users['s3 tenant']['display_name']}
+user_id = {users['s3 tenant']['uid']}
+email = {users['s3 tenant']['email']}
+access_key = {users['s3 tenant']['access_key']}
+secret_key = {users['s3 tenant']['secret_key']}
+
+[iam]
+email = s3@example.com
+user_id = testid
+access_key = test
+secret_key = test
+display_name = youruseridhere
+    """
+
+
+def run_test(docker_api, image, container_run_args, s3_tests, name, port):
+    start_time_ns = time.perf_counter_ns()
+    cri = docker.DockerClient(base_url=docker_api)
+    container_name = name.split("::")[1]
+    container = S3GW(cri, image, container_run_args, container_name, port)
+    container.start()
+
+    for retry in range(10):
+        if container.http_up():
+            break
+        time.sleep(1 * retry)
+
+    if not container.http_up():
+        return {
+            "test": name,
+            "test_return": "fail",
+            "container_return": "fail",
+            "container_logs": container.logfile(),
+            "test_output": "",
+            "test_data": "",
+            "runtime_ns": time.perf_counter_ns() - start_time_ns,
+        }
+
+    for user in S3TESTS_USERS.values():
+        ret = container.create_user(**user)
+        LOG.debug(f"Created test user: {ret}")
+
+    with tempfile.NamedTemporaryFile() as config_fp, \
+         tempfile.NamedTemporaryFile() as json_out_fp:  # fmt: skip
+        config_fp.write(
+            mk_config(container.network_address(), port, S3TESTS_USERS).encode("ascii")
+        )
+        config_fp.flush()
+        try:
+            cmd = [
+                "pytest",
+                "-v",
+                "--json-report",
+                f"--json-report-file={json_out_fp.name}",
+                "--",
+                name,
+            ]
+            env = dict(**os.environ)
+            env["S3TEST_CONF"] = config_fp.name
+            LOG.debug(f"running {cmd} with {env} cwd {s3_tests}")
+            proc = subprocess.run(
+                cmd,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=PYTEST_TIMEOUT_SEC,
+                cwd=s3_tests,
+                env=env,
+            )
+            ret = "success"
+            out = proc.stdout.decode("utf-8")
+            data_out = json.load(json_out_fp)["tests"][0]
+        except subprocess.CalledProcessError as e:
+            ret = "fail"
+            out = e.output.decode("utf-8")
+            data_out = json.load(json_out_fp)["tests"][0]
+        except subprocess.TimeoutExpired as e:
+            ret = "timeout"
+            out = e.output.decode("utf-8")
+            try:
+                data_out = json.load(json_out_fp)["tests"][0]
+            except Exception:
+                data_out = {}
+        except Exception as e:
+            LOG.exception("unhandled exception during test %s. rethrowing.", name)
+            raise e
+
+    container_ret = container.stop()
+    logs = container.logfile()
+    container.remove()
+    return {
+        "test": name,
+        "test_return": ret,
+        "container_return": container_ret,
+        "container_logs": logs,
+        "test_output": out,
+        "test_data": data_out,
+        "runtime_ns": time.perf_counter_ns() - start_time_ns,
+    }
+
+
+def run_test_unpack(args):
+    return run_test(*args)
+
+
+def run_tests(docker_api, image, container_run_args, s3_tests, nproc, tests):
+    start_port = 10000
+    jobs = [
+        (docker_api, image, container_run_args, s3_tests, test, start_port + i)
+        for i, test in enumerate(tests)
+    ]
+    results = []
+    with multiprocessing.Pool(nproc) as pool:
+        for result in pool.imap_unordered(run_test_unpack, jobs, chunksize=1):
+            results.append(result)
+            if (len(results) % 10) == 0:
+                mean_runtime_ns = int(
+                    sum(r["runtime_ns"] for r in results) / len(results)
+                )
+                estimated_time_left_ns = int(
+                    mean_runtime_ns * (len(jobs) - len(results)) / nproc
+                )
+                LOG.info(
+                    f"{len(results)}/{len(jobs)} done. "
+                    f"mean runtime {int(mean_runtime_ns/10**9)}s. "
+                    f"estimated time left {int(estimated_time_left_ns/10**9)}s. "
+                )
+    return results
+
+
+def cleanup(cri):
+    LOG.info("Cleaning up")
+    for _ in range(3):
+        try:
+            for c in cri.containers.list(all=True, filters={"label": "s3gw_s3tests"}):
+                LOG.debug(f"Removing container {c}")
+                c.stop(timeout=2)
+                c.remove()
+        except Exception:
+            continue
+
+
+class JSONParamType(click.ParamType):
+    name = "JSON"
+
+    def convert(self, value, param, ctx):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as e:
+            self.fail(f"{value!r} is not valid JSON: {e}", param, ctx)
+
+
+@click.command()
+@click.option(
+    "--docker-api",
+    type=str,
+    envvar="DOCKER_API",
+    default="unix:///var/run/docker.sock",
+    help="Docker API URI. e.g unix://run/podman/podman.sock",
+)
+@click.option(
+    "--tests",
+    type=str,
+    default="s3tests_boto3/functional/test_s3.py",
+    help="pytest search string / path e.g s3tests_boto3/functional/test_s3.py",
+)
+@click.option(
+    "--nproc",
+    type=int,
+    default=42,
+    help="processing pool size",
+)
+@click.option(
+    "--sample",
+    type=int,
+    default=0,
+    help="> 0 run random sample of tests",
+)
+@click.option(
+    "--image",
+    type=str,
+    default="quay.io/s3gw/s3gw:latest",
+)
+@click.option(
+    "--s3-tests",
+    envvar="S3TESTS",
+    type=click.Path(
+        file_okay=False, dir_okay=True, allow_dash=False, path_type=pathlib.Path
+    ),
+)
+@click.option(
+    "--extra-container-args",
+    help=(
+        "Extra keyword arguments to pass to container.run as JSON object"
+        "(See https://docker-py.readthedocs.io/en/stable/containers.html#"
+        "docker.models.containers.ContainerCollection.run)"
+    ),
+    type=JSONParamType(),
+    default="{}",
+)
+@click.argument("output", type=click.File("w"))
+def run(
+    docker_api, tests, nproc, sample, image, s3_tests, output, extra_container_args
+):
+    """
+    Run all or selected (--tests) s3tests against s3gw container image (--image)
+    using a Docker compatible API endpoint (--docker-api).
+    """
+    if (
+        docker_api.startswith("unix")
+        and not pathlib.Path(docker_api[len("unix:") :]).exists()
+    ):
+        LOG.critical(
+            f"Docker API set to unix socket ({docker_api}), "
+            "but file does not exist. Add docker volume?"
+        )
+        sys.exit(2)
+
+    tests = get_tests(s3_tests, tests)
+    if sample > 0:
+        tests = random.sample(tests, sample)
+    LOG.debug(f"Running {len(tests)} tests: {tests}")
+    LOG.info(
+        f"Running {nproc} tests in parallel against "
+        f"image {image} "
+        f"with docker API {docker_api} "
+        f"with s3-tests in {s3_tests}"
+    )
+    LOG.info(
+        'Running radosgw with command "%s"',
+        " ".join(make_radosgw_command("PLACEHOLDER", "PLACEHOLDER")),
+    )
+    try:
+        results = run_tests(
+            docker_api, image, extra_container_args, s3_tests, nproc, tests
+        )
+        LOG.info(f"Done. Ran {len(results)} tests.")
+        json.dump(results, output)
+        output.flush()
+        LOG.info(f"Writing results to {output}")
+    finally:
+        cleanup(docker.DockerClient(base_url=docker_api))
+
+
+if __name__ == "__main__":
+    run()

--- a/tools/s3tests/s3tr.py
+++ b/tools/s3tests/s3tr.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+"""
+A s3-tests runner tailored to s3gw containers with parallel execution,
+result and log gathering
+"""
+
+import logging
+
+import analyze
+import click
+import runner
+import to_sqlite
+
+LOG = logging.getLogger("s3tr")
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--debug/--no-debug", default=False)
+def s3tr(debug):
+    """
+    s3tr - s3gw project s3tests runner
+    """
+    loglevel = [logging.INFO, logging.DEBUG][int(debug)]
+    logging.basicConfig(
+        level=loglevel, format="%(name)s: %(message)s", datefmt="[%Y-%m-%d %H:%M:%S]"
+    )
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.WARN)
+    logging.getLogger("docker.auth").setLevel(logging.INFO)
+    logging.getLogger("docker.utils.config").setLevel(logging.INFO)
+    logging.getLogger("boto").setLevel(logging.WARN)
+
+
+if __name__ == "__main__":
+    s3tr.add_command(runner.run)
+    s3tr.add_command(to_sqlite.to_sqlite)
+    s3tr.add_command(to_sqlite.datasette)
+    s3tr.add_command(analyze.analyze)
+    s3tr()

--- a/tools/s3tests/setup
+++ b/tools/s3tests/setup
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -x
+
+SCRIPTPATH="$(dirname "$0")"
+
+: $S3TESTS
+
+if [[ ! -d "$S3TESTS" ]]; then
+    echo "Please set S3TESTS to s3-tests directory"
+    exit 1
+fi
+
+if [[ ! -d "$SCRIPTPATH/venv" ]]; then
+   (
+       cd $SCRIPTPATH
+       python3 -m venv venv
+       source venv/bin/activate
+       pip install -r "$S3TESTS/requirements.txt"
+       pip install -r "requirements.txt"
+   )
+fi

--- a/tools/s3tests/to_sqlite.py
+++ b/tools/s3tests/to_sqlite.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Convert s3gw s3 tests runner JSON results
+to an SQLite database suitable to Datasette
+"""
+
+import configparser
+import json
+import logging
+import pathlib
+import tempfile
+
+import click
+import sqlite_utils
+import uvicorn
+import yaml
+from datasette.app import Datasette
+
+LOG = logging.getLogger("s3tr")
+
+
+def get_test_result(result):
+    ret = result["test_return"]
+    logs = result["container_logs"]
+    if "Segmentation fault" in logs:
+        return f"{ret}+segfault"
+    if "FAILED ceph_assert" in logs:
+        return f"{ret}+assertion"
+    elif "BUG Unhandled exception" in logs:
+        return f"{ret}+unhandled exception"
+    elif "end dump of recent events" in logs:
+        return f"{ret}+crash"
+
+    return ret
+
+
+def get_keywords(result, markers):
+    if result["test_data"]:
+        return markers & frozenset(result["test_data"]["keywords"])
+    else:
+        return set()
+
+
+def make_full_results_database(results, pytest_markers, db_path):
+    db = sqlite_utils.Database(db_path)
+    for i, result in enumerate(results):
+        keywords = get_keywords(result, pytest_markers)
+        row = {
+            "test": result["test"].split("::")[1],
+            "result": get_test_result(result),
+            "out": result["test_output"],
+            "log_container": result["container_logs"],
+        }
+        db["results"].insert(row, pk="test")
+        for keyword in keywords:
+            db["results_keywords"].insert(
+                {"test": row["test"], "keyword": keyword},
+                foreign_keys=[("test", "results", "test")],
+                pk="id",
+            )
+
+        if (i % 50) == 0:
+            LOG.info(f"{i}/{len(results)} done")
+
+    db.create_view(
+        "results_with_keywords",
+        """
+       select
+         results.test,
+         json_group_array(results_keywords.keyword) as keywords, result
+       from results inner join results_keywords
+       on results.test = results_keywords.test
+       group by results.test
+    """,
+    )
+    db["results"].enable_fts(["out", "log_container"])
+    db["results"].create_index(["result"])
+    db["results_keywords"].create_index(["keyword"])
+    db["results_keywords"].create_index(["test"])
+
+
+def make_comparison_database(results_by_versions, db_path):
+    db = sqlite_utils.Database(db_path)
+    db["versions"].insert_all(
+        [
+            {"name": version, "id": result["index"]}
+            for version, result in results_by_versions.items()
+        ],
+        pk="id",
+    )
+    for results in results_by_versions.values():
+        for result in results:
+            db["results"].insert(
+                {
+                    "test": result["test"].split("::")[1],
+                    "result": get_test_result(result),
+                    "version_id": result["index"],
+                },
+                pk="id",
+                foreign_keys=("version_id", "versions"),
+            )
+
+
+@click.group()
+def to_sqlite():
+    """
+    Convert JSON test results into SQLite databases
+    """
+    pass
+
+
+@click.group()
+def datasette():
+    """
+    Open results in datasette
+    """
+    pass
+
+
+@to_sqlite.command()
+@click.option(
+    "--pytest-ini",
+    envvar="PYTEST_INI",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+)
+@click.argument(
+    "db_path",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+)
+@click.argument("input", type=click.File("r"))
+def convert(pytest_ini, db_path, input):
+    """
+    Create sqlite database with full logs and test output from a
+    single testrun JSON file
+    """
+    results = json.load(input)
+    ini_parser = configparser.ConfigParser()
+    ini_parser.read(pytest_ini)
+    markers = frozenset(ini_parser["pytest"]["markers"].split())
+    make_full_results_database(results, markers, db_path)
+
+
+@datasette.command()
+@click.option(
+    "--pytest-ini",
+    envvar="PYTEST_INI",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+)
+@click.option(
+    "--datasette-metadata",
+    envvar="DATASETTE_METADATA",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+)
+@click.argument("input", type=click.File("r"))
+def serve(pytest_ini, datasette_metadata, input):
+    """
+    Open full results for a single run in datasette
+    """
+    results = json.load(input)
+    ini_parser = configparser.ConfigParser()
+    ini_parser.read(pytest_ini)
+    markers = frozenset(ini_parser["pytest"]["markers"].split())
+    with open(datasette_metadata) as fp:
+        metadata = yaml.safe_load(fp)
+
+    with tempfile.TemporaryDirectory() as tmpdir, open(
+        pathlib.Path(tmpdir) / "results.db", "w"
+    ) as db_file:
+        LOG.info(f"Converting {input} to SQLite {db_file.name}")
+        make_full_results_database(results, markers, db_file.name)
+
+        ds = Datasette(files=[db_file.name], metadata=metadata)
+        LOG.info(f"Starting datasette {ds}")
+        uvicorn.run(ds.app(), host="0.0.0.0", port=8080, lifespan="on", workers=1)
+
+
+@to_sqlite.command()
+@click.argument(
+    "db_path",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+)
+@click.argument(
+    "input_files",
+    type=click.Path(
+        file_okay=True, dir_okay=False, allow_dash=False, path_type=pathlib.Path
+    ),
+    required=True,
+    nargs=-1,
+)
+def comparison(pytest_ini, db_path, input_files):
+    """
+    Create comparison database from result json files
+    """
+    results_by_versions = {}
+    for i, file in enumerate(input_files):
+        with open(file) as fp:
+            results = json.load(fp)
+        results["index"] = i
+        results_by_versions[file.name] = results
+
+    make_comparison_database(results_by_versions, db_path)
+
+
+if __name__ == "__main__":
+    to_sqlite()


### PR DESCRIPTION
Yet another S3 tests runner.. This one tailored to analysis (with Datasette) and written in Python. 

Datasette instance for latest s3gw results: https://s3gw-s3test-results.fly.dev/results


## Components

s3tests runner: Run tests isolated against fresh containers. Collect test and container logs. Outputs a JSON file with logs and pytest metadata.

to_sqlite: Convert runner JSON to a SQLite database suitable to use with Datasette

metadata.yml: Datasette metadata config with canned queries and predefined facets.

Let pre-commit cover the new Python code with the existing releasetool checks.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
