### PR TITLE
docs: link release notes v0.15 to v0.17

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,3 +58,6 @@ nav:
       - v0.12.0: "release-notes/s3gw-v0.12.0.md"
       - v0.13.0: "release-notes/s3gw-v0.13.0.md"
       - v0.14.0: "release-notes/s3gw-v0.14.0.md"
+      - v0.15.0: "release-notes/s3gw-v0.15.0.md"
+      - v0.16.0: "release-notes/s3gw-v0.16.0.md"
+      - v0.17.0: "release-notes/s3gw-v0.17.0.md"


### PR DESCRIPTION
Link release notes for v0.15 to v0.17 in documentation.

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
