### PR TITLE
build: Install ceph crypto plugins

### DIFF
--- a/tools/build/Dockerfile.build-container
+++ b/tools/build/Dockerfile.build-container
@@ -47,6 +47,11 @@ COPY [ \
        "./lib/libceph-common.so.2", \
        "/radosgw/" ]
 
+COPY [ \
+  "./lib/libceph_crypto_isal.so", \
+  "./lib/libceph_crypto_openssl.so", \
+  "/usr/local/lib64/ceph/crypto/" ]
+
 EXPOSE 7480
 
 VOLUME ["/data"]


### PR DESCRIPTION
Install crypto plugins that may be loaded at runtime by radosgw.

Requires them to be built by the build tool in aquarist-labs/ceph.

# Describe your changes

## Issue ticket number and link

Issue: https://github.com/aquarist-labs/s3gw/issues/521
Requires PR: https://github.com/aquarist-labs/ceph/pull/158

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
