### PR TITLE
ci: authenticate against ghcr.io

### DIFF
--- a/.github/workflows/build-s3tr.yaml
+++ b/.github/workflows/build-s3tr.yaml
@@ -24,6 +24,13 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
When building and pushing the s3test runner tool, authenticate against the GitHub registry using the automatically provided token for the workflow.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
