### PR TITLE
ci: unittest container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,11 @@ RUN /srv/ceph/qa/rgw/store/sfs/build-radosgw.sh
 
 FROM s3gw-base as s3gw-unittests
 
+RUN zypper -n install --no-recommends \
+      gtest \
+      gmock \
+ && zypper clean --all
+
 COPY --from=buildenv /srv/ceph/build/bin/unittest_rgw_* /radosgw/bin/
 COPY --from=buildenv [ \
   "/srv/ceph/build/lib/librados.so", \


### PR DESCRIPTION
Add gtest/gmock to the runtime container for executing the unittests. If the unittests are built with system gtest/gmock instead of linking it in statically, those libraries need to be supplied in the runtime container image for executing the unittests


- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
