### PR TITLE
ci: enable all s3tests for nightlies

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -130,9 +130,8 @@ jobs:
           export S3TEST_CONF="${FIXTURES}/s3tests.conf"
           export S3TEST_LIST="${FIXTURES}/s3-tests.txt"
 
-          # There are some s3tests that don't finish at all. Only run
-          # known-to-pass tests for now. TODO: fix inifite looping tests
-          # sed -r -i 's/^# //' "${S3TEST_LIST}"
+          # Let _all_ tests run, not just the ones that are known to pass
+          sed -r -i 's/^# //' "${S3TEST_LIST}"
 
           pushd s3tests
           ${GITHUB_WORKSPACE}/s3gw/tools/tests/s3tests-runner.sh


### PR DESCRIPTION
Enable all s3tests for nightlies, regardless of whether or not they pass.

Fixes: #14 

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
