### PR TITLE
Dockerfile: drop libsqliteorm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,6 @@ RUN zypper -n install --no-recommends \
       libpmemobj-devel \
       librabbitmq-devel \
       librdkafka-devel \
-      libsqliteorm \
       libstdc++6-devel-gcc12 \
       libtool \
       libtsan0 \

--- a/tools/build/Dockerfile.build-radosgw
+++ b/tools/build/Dockerfile.build-radosgw
@@ -59,7 +59,6 @@ RUN zypper -n install --no-recommends \
       libpmemobj-devel \
       librabbitmq-devel \
       librdkafka-devel \
-      libsqliteorm \
       libstdc++6-devel-gcc12 \
       libtool \
       libtsan0 \

--- a/tools/build/Dockerfile.s3gw
+++ b/tools/build/Dockerfile.s3gw
@@ -93,7 +93,6 @@ RUN zypper -n install --no-recommends \
       libpmemobj-devel \
       librabbitmq-devel \
       librdkafka-devel \
-      libsqliteorm \
       libstdc++6-devel-gcc11 \
       libtool \
       libtsan0 \


### PR DESCRIPTION
This removes the libsqliteorm dependency which won't be necessary once https://github.com/aquarist-labs/ceph/pull/212 goes in and sqlite_orm is included as a submodule.

Fixes: https://github.com/aquarist-labs/s3gw/issues/683

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
