### PR TITLE
Dockerfile: fix sqlite version to 3.43.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN zypper ar \
  && zypper --gpg-auto-import-keys ref
 
 RUN zypper -n install \
+  libsqlite3-0=3.43.1 \
   libblkid1 \
   libexpat1 \
   libtcmalloc4 \


### PR DESCRIPTION
To be merged after @tserong updates the  packages in https://build.opensuse.org/project/show/filesystems:ceph:s3gw and adds the newest sqlite3 3.43.1 version.

Fixes: aquarist-labs/s3gw#725

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>