### PR TITLE
Dockerfile: Add filesystems:ceph:s3gw repomd.xml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM opensuse/leap:15.4 as s3gw-base
 
+# This makes sure the Docker cache is invalidated
+# if packages in the s3gw repo on OBS have changed
+ADD https://download.opensuse.org/repositories/filesystems:/ceph:/s3gw/15.4/repodata/repomd.xml /tmp/
 RUN zypper ar \
   https://download.opensuse.org/repositories/filesystems:/ceph:/s3gw/15.4/ \
   s3gw-deps \


### PR DESCRIPTION
Without this, the subsequent `zypper install ; zypper ref` is effectively a no-op if docker build has already been run and cached that layer, which means we don't pick up updated package versions.

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
