### PR TITLE
docs/ideas: define PID records

### DIFF
--- a/docs/ideas/PID-0-reserved.md
+++ b/docs/ideas/PID-0-reserved.md
@@ -1,0 +1,71 @@
+---
+status: accepted
+tags: area/docs
+updated: 20231013
+---
+
+# Project Idea Document (PID)
+
+## Context and Problem Statement
+
+We want to record ideas for features, enhancements, and reasonably sane brain
+dumps.
+
+Project Idea Documents (henceforth, PID) are therefore records, much like the
+ADRs we use for decisions, but fall on a different category: these are not
+decisions made by anyone, just a description of something to be considered for
+the future.
+
+## Format
+
+PIDs should observe the following qualities:
+
+- Easy to read and review
+- Include enough information to be understood by others, and its merit assessed
+- Reference all relevant GitHub project issues, if they exist
+- Be a single file
+- File name should follow the `PID-yyyymmdd-title.md` format
+
+PID-0 is the only PID record that is allowed to break the file name convention.
+
+All PIDs should be kept under `/docs/ideas/` in the `aquarist-labs/s3gw`
+repository.
+
+### PID Structure
+
+We do not enforce a strict document structure, but it should be easily
+understood.
+
+However, the following rules always apply:
+
+- The PID title should always reflect the idea being proposed
+- Metadata is required at the beginning of the record
+
+We recommend always starting the document with a `Context and Problem Statement`
+section, and finishing with a `References` section if applicable.
+
+### Metadata
+
+All PIDs should include at least the following metadata at the beginning of its
+record:
+
+```yaml
+---
+status: <proposed | accepted | rejected | superseded by [PID-yyyymmdd](/docs/ideas/PID-yyyymmdd-foo.md)]>
+tags: <area/foo>
+updated: <yyyymmdd>
+---
+```
+
+The `status` fields translate as the following:
+
+- proposed: The idea has been proposed to the project, and, being part of the
+  repository after being merged, its proposal status has been granted
+- accepted: The idea has been accepted as a work item at some point in time
+- rejected: The idea has been rejected at some point in time
+- superseded: A new, better idea came up, superseding this one
+
+The `tags` field should reflect **at least** the `area/` to which an idea
+applies. Other tags may be provided, as long as they make sense.
+
+The `updated` field should reflect the last date a given PID was updated.


### PR DESCRIPTION
This patch introduces the concept of Project Idea Document (PID), meant to record ideas in a simple, straighforward way, for future reference and to track all the bright ideas we have.

These are meant to track ideas that

  - are not yet planned to be worked on
  - are not fully designed
  - may need to be evaluated at a later time

However, all PIDs should include enough information to assess their merit before being merged.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>