### PR TITLE
docs/matrix: update compatibility matrix

### DIFF
--- a/docs/s3-compatibility-table.md
+++ b/docs/s3-compatibility-table.md
@@ -13,6 +13,7 @@ functional features, and our forward-looking plans for upcoming releases.
 | Bucket Lifecycle       | 🟨      | ✅     | ✅     |
 | Object Locking         | ✅      | ✅     | ✅     |
 | Bucket/User Quotas     | ✅      | ✅     | ✅     |
+| Get Object Part        | 🟥      | 🔹     | 🔹     |
 | Server Side Encryption | 🟥      | ✅     | ✅     |
 | Bucket Website         | 🟥      | ✅     | ✅     |
 | Bucket Notifications   | 🟥      | 🔹     | ✅     |

--- a/docs/s3-compatibility-table.md
+++ b/docs/s3-compatibility-table.md
@@ -3,25 +3,27 @@
 The following table represents the support status for current Amazon S3
 functional features, and our forward-looking plans for upcoming releases.
 
-|                        | v0.24.0 | v1.0.0 | v1.x.0 |
-| ---------------------- | ------- | ------ | ------ |
-| GET/PUT/DELETE         | ✅      | ✅     | ✅     |
-| Multipart Uploads      | ✅      | ✅     | ✅     |
-| Bucket/Object ACLs     | ✅      | ✅     | ✅     |
-| Bucket Object Versions | ✅      | ✅     | ✅     |
-| Bucket/Object Tagging  | ✅      | ✅     | ✅     |
-| Bucket Lifecycle       | 🟨      | ✅     | ✅     |
-| Object Locking         | ✅      | ✅     | ✅     |
-| Bucket/User Quotas     | ✅      | ✅     | ✅     |
-| Get Object Part        | 🟥      | 🔹     | 🔹     |
-| Server Side Encryption | 🟥      | ✅     | ✅     |
-| Bucket Website         | 🟥      | ✅     | ✅     |
-| Bucket Notifications   | 🟥      | 🔹     | ✅     |
-| Bucket Request Payment | 🟥      | 🟥     | 🔹     |
-| S3 Storage Classes     | 🟥      | 🟥     | 🔹     |
-| Bucket Policy          | 🟥      | 🟥️     | 🔹     |
-| IAM / STS              | 🟥      | 🟥     | 🔹     |
-| Bucket Replication     | 🟥      | 🟥     | 🟥     |
+|                                 | v0.24.0 | v1.0.0 | v1.x.0 |
+| ------------------------------- | ------- | ------ | ------ |
+| GET/PUT/DELETE                  | ✅      | ✅     | ✅     |
+| Multipart Uploads               | ✅      | ✅     | ✅     |
+| Bucket/Object ACLs              | ✅      | ✅     | ✅     |
+| Bucket Object Versions          | ✅      | ✅     | ✅     |
+| Bucket/Object Tagging           | ✅      | ✅     | ✅     |
+| Bucket Lifecycle                | 🟨      | ✅     | ✅     |
+| Object Locking                  | ✅      | ✅     | ✅     |
+| Bucket/User Quotas              | ✅      | ✅     | ✅     |
+| Get Object Part                 | 🟥      | 🔹     | 🔹     |
+| Server Side Encryption          | 🟥      | ✅     | ✅     |
+| Bucket unversioned -> versioned | 🟥      | ✅     | ✅     |
+| Bucket version suspension       | 🟥      | 🟥     | 🔹     |
+| Bucket Website                  | 🟥      | ✅     | ✅     |
+| Bucket Notifications            | 🟥      | 🔹     | ✅     |
+| Bucket Request Payment          | 🟥      | 🟥     | 🔹     |
+| S3 Storage Classes              | 🟥      | 🟥     | 🔹     |
+| Bucket Policy                   | 🟥      | 🟥️     | 🔹     |
+| IAM / STS                       | 🟥      | 🟥     | 🔹     |
+| Bucket Replication              | 🟥      | 🟥     | 🟥     |
 
 🔹 - under consideration / 🟥 - not planned / 🟨 - partial support /
 ✅ - expected support


### PR DESCRIPTION
We don't support obtaining an object's specific part once the object's multipart upload has been finished.

This is a limitation of the current RGW implementation.

Also, update the matrix stating that we don't support bucket version suspension, nor do we support (for now) transitioning from an unversioned bucket to a versioned bucket.

References: aquarist-labs/s3gw#749

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>