### PR TITLE
ci: run unittests in the nightly test suite

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -91,8 +91,22 @@ jobs:
           DATE="$(date +%Y-%m-%d)"
           echo "tag=nightly-${DATE}" >> $GITHUB_OUTPUT
 
+      - name: Build Unittest Container
+        uses: docker/build-push-action@v4
+        with:
+          load: true
+          build-args: |
+            CMAKE_BUILD_TYPE=Release
+            S3GW_VERSION=${{ steps.date.outputs.tag }}
+            NPROC=16
+          tags: |
+            s3gw-unittests
+          target: s3gw-unittests
+          file: s3gw/Dockerfile
+          context: s3gw
+
       - name: Build Nightly Container
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           build-args: |
@@ -105,6 +119,10 @@ jobs:
             quay.io/s3gw/s3gw:nightly-latest
           file: s3gw/Dockerfile
           context: s3gw
+
+      - name: Run Unittests
+        run: |
+          docker run --rm s3gw-unittests
 
       - name: Run S3tests
         env:


### PR DESCRIPTION
Run the unittests during testing of the nightly build.

Fixes: #664
Replaces PR #666

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
