### PR TITLE
Update container base image to leap or bci 15.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM opensuse/leap:15.4 as s3gw-base
+FROM registry.suse.com/bci/bci-base:15.5 as s3gw-base
 
 # This makes sure the Docker cache is invalidated
 # if packages in the s3gw repo on OBS have changed
-ADD https://download.opensuse.org/repositories/filesystems:/ceph:/s3gw/15.4/repodata/repomd.xml /tmp/
-# Add OBS repository for additional dependencies necessary on Leap 15.4
+ADD https://download.opensuse.org/repositories/filesystems:/ceph:/s3gw/15.5/repodata/repomd.xml /tmp/repodata-s3gw.xml
+# Add OBS repository for additional dependencies necessary on Leap 15.5
 RUN zypper ar \
-  https://download.opensuse.org/repositories/filesystems:/ceph:/s3gw/15.4/ \
+  https://download.opensuse.org/repositories/filesystems:/ceph:/s3gw/15.5/ \
   s3gw-deps \
  && zypper --gpg-auto-import-keys ref
 
@@ -48,6 +48,17 @@ ARG CMAKE_BUILD_TYPE=Debug
 
 ENV SRC_CEPH_DIR="${SRC_CEPH_DIR:-"./ceph"}"
 ENV ENABLE_GIT_VERSION=OFF
+
+# Needed for extra build deps
+ADD https://download.opensuse.org/update/leap/15.5/oss/repodata/repomd.xml /tmp/repodata-update.xml
+ADD https://download.opensuse.org/update/leap/15.5/backports/repodata/repomd.xml /tmp/repodata-backports-update.xml
+ADD https://download.opensuse.org/update/leap/15.5/sle/repodata/repomd.xml /tmp/repodata-sle-update.xml
+RUN zypper ar \
+  http://download.opensuse.org/distribution/leap/15.5/repo/oss/ repo-oss \
+ && zypper ar http://download.opensuse.org/update/leap/15.5/oss/ repo-update \
+ && zypper ar http://download.opensuse.org/update/leap/15.5/backports/ repo-backports-update \
+ && zypper ar http://download.opensuse.org/update/leap/15.5/sle/ repo-sle-update \
+ && zypper --gpg-auto-import-keys ref
 
 # Try `zypper install` up to three times to workaround mirror timeouts
 RUN for i in {1..3} ; do zypper -n install --no-recommends \
@@ -109,7 +120,7 @@ RUN for i in {1..3} ; do zypper -n install --no-recommends \
       libtsan0 \
       libxml2-devel \
       lttng-ust-devel \
-      lua-devel \
+      lua53-devel \
       lua53-luarocks \
       make \
       memory-constraints \


### PR DESCRIPTION
There's two commits here for review. Depending on which way we want to go we can either just take the first one and get leap 15.5, or I can squash the two to give us bci 15.5.

The leap 15.5 change is extremely straightforward (`s/15.5/15.5/g`). With bci though, we lack a bunch of ceph's build dependencies. Rather that drag all those over into filesystems:ceph:s3gw on OBS (which was looking to be a PITA), I've added the _leap_ 15.5 repos to the buildenv image. AIUI this is safe because 15.5 should be binary compatible across the board, and anyway it only affects the build environment, not s3gw-base or the final s3gw container. Does this sound sane to everyone?

I haven't removed any other build deps as mentioned in #771, as I wanted to focus of setting the base image first. I'll do more stripping if I can later.