### PR TITLE
readthedocs: specify build.os

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,10 +6,10 @@
 version: 2
 
 # Set the version of Python and other tools you might need
-# build:
-#   os: ubuntu-22.04
-#   tools:
-#     python: "3.10"
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
Builds are failing for a few weeks, due to a missing build.os.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>
