### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -97,7 +97,7 @@ jobs:
             --build-arg S3GW_VERSION=${{ steps.date.outputs.tag }} \
             --build-arg QUAY_EXPIRATION=1w \
             --file s3gw/Dockerfile \
-            --tag quay.io/s3gw/s3gw:latest \
+            --tag quay.io/s3gw/s3gw:nightly-latest \
             --tag quay.io/s3gw/s3gw:${{ steps.date.outputs.tag }} \
             s3gw
           docker push quay.io/s3gw/s3gw:nightly-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,25 +13,6 @@ on:
   workflow_dispatch:   # Or manually - for testing
 
 jobs:
-  prune1:
-    runs-on: self-hosted
-    steps:
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Context
-        run: |
-          docker context create builder
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          endpoint: builder
-
-      - name: Docker prune
-
-
   build-and-test:
     runs-on: self-hosted
     steps:
@@ -85,18 +66,6 @@ jobs:
           python3 -m pip install boto3==1.24.96
           python3 -m pip install -r s3tests/requirements.txt
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Context
-        run: |
-          docker context create builder
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          endpoint: builder
-
       - name: Quay Login
         uses: docker/login-action@v2
         with:
@@ -110,34 +79,29 @@ jobs:
           DATE="$(date +%Y-%m-%d)"
           echo "tag=nightly-${DATE}" >> $GITHUB_OUTPUT
 
-      - name: Build Unittest Container
-        uses: docker/build-push-action@v4
-        with:
-          load: true
-          build-args: |
-            CMAKE_BUILD_TYPE=Release
-            S3GW_VERSION=${{ steps.date.outputs.tag }}
-            NPROC=16
-          tags: |
-            s3gw-unittests
-          target: s3gw-unittests
-          file: s3gw/Dockerfile
-          context: s3gw
+      - name: Build Unittests
+        run: |
+          docker build \
+            --build-arg CMAKE_BUILD_TYPE=Release \
+            --build-arg NPROC=16 \
+            --file s3gw/Dockerfile \
+            --tag s3gw-unittests \
+            --target s3gw-unittests \
+            s3gw
 
-      - name: Build Nightly Container
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          build-args: |
-            CMAKE_BUILD_TYPE=Release
-            S3GW_VERSION=${{ steps.date.outputs.tag }}
-            NPROC=16
-            QUAY_EXPIRATION=1w
-          tags: |
-            quay.io/s3gw/s3gw:${{ steps.date.outputs.tag }}
-            quay.io/s3gw/s3gw:nightly-latest
-          file: s3gw/Dockerfile
-          context: s3gw
+      - name: Build s3gw Container Image
+        run: |
+          docker build \
+            --build-arg CMAKE_BUILD_TYPE=Release \
+            --build-arg NPROC=16 \
+            --build-arg S3GW_VERSION=${{ steps.date.outputs.tag }} \
+            --build-arg QUAY_EXPIRATION=1w \
+            --file s3gw/Dockerfile \
+            --tag quay.io/s3gw/s3gw:latest \
+            --tag quay.io/s3gw/s3gw:${{ steps.date.outputs.tag }} \
+            s3gw
+          docker push quay.io/s3gw/s3gw:nightly-latest
+          docker push quay.io/s3gw/s3gw:${{ steps.date.outputs.tag }}
 
       - name: Run Unittests
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,18 +16,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Context
-        run: |
-          docker context create builder
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          endpoint: builder
-
       - name: Quay Login
         uses: docker/login-action@v2
         with:
@@ -36,36 +24,32 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build Unittests
-        uses: docker/build-push-action@v4
-        with:
-          load: true
-          build-args: |
-            CMAKE_BUILD_TYPE=Release
-            NPROC=16
-          tags: |
-            s3gw-unittests
-          target: s3gw-unittests
-          file: Dockerfile
-          context: .
+        run: |
+          docker build \
+            --build-arg CMAKE_BUILD_TYPE=Release \
+            --build-arg NPROC=16 \
+            --file Dockerfile \
+            --tag s3gw-unittests \
+            --target s3gw-unittests \
+            .
 
       - name: Run Unittests
         run: |
           docker run --rm s3gw-unittests
 
       - name: Build s3gw Container Image
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          build-args: |
-            CMAKE_BUILD_TYPE=Release
-            S3GW_VERSION=${{ github.ref_name }}
-            NPROC=16
-            QUAY_EXPIRATION=Never
-          tags: |
-            quay.io/s3gw/s3gw:latest
-            quay.io/s3gw/s3gw:${{ github.ref_name }}
-          file: Dockerfile
-          context: .
+        run: |
+          docker build \
+            --build-arg CMAKE_BUILD_TYPE=Release \
+            --build-arg NPROC=16 \
+            --build-arg S3GW_VERSION=${{ github.ref_name }} \
+            --build-arg QUAY_EXPIRATION=Never \
+            --file Dockerfile \
+            --tag quay.io/s3gw/s3gw:latest \
+            --tag quay.io/s3gw/s3gw:${{ github.ref_name }} \
+            .
+          docker push quay.io/s3gw/s3gw:latest
+          docker push quay.io/s3gw/s3gw:${{ github.ref_name }}
 
   pre-release-smoke-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Describe your changes

Drop docker buildx from the release workflow. The builds using buildx had various issues with timeouts and TLS errors.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
