### PR TITLE
.github/workflows: don't lint releases (backport)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,15 +1,18 @@
 ---
 name: Lint
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  push:
+    branches-ignore:
+      - "s3gw-v*"
+    tags-ignore:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-
       - name: Set up Git repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Linting a release branch makes little sense.

And the action being used in the `lint.yaml` workflow relies on obtaining a list of changed files since the base commit. This action seems to presume this will be used for pull requests, or tags that are on the same branch as `main`. Once we do a release branch and a release tag, the action is unable to figure out how to calculate the diff in versions, and we end up with unnecessary failures.


(cherry picked from commit cae010bbf74e1febaa6f81d0fd21a650f566a8dd)
Signed-off-by: Joao Eduardo Luis \<joao@suse.com>